### PR TITLE
Stat and bytesToHuman fix

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Build C++ lib/program and tests
               run: cd build && make -j$(nproc) test ddbcmd
             - name: Run C++ Tests
-              run: cd build/test && ./test
+              run: cd build && ./test.run
             - name: Run Program Smoke Test
               run: cd build && ./ddb --debug
             - name: Build Distribution

--- a/src/entry.h
+++ b/src/entry.h
@@ -26,7 +26,7 @@ struct Entry {
     EntryType type = EntryType::Undefined;
     json meta;
     time_t mtime = 0;
-    off_t size = 0;
+    std::uintmax_t size = 0;
     int depth = 0;
 
     BasicPointGeometry point_geom;

--- a/src/mio.cpp
+++ b/src/mio.cpp
@@ -71,7 +71,6 @@ std::uintmax_t Path::getSize() {
         CloseHandle(hFile);
         throw FSException("Cannot stat size (getfilesize) " + p.string());
     }
-    LOGD << size.QuadPart;
     CloseHandle(hFile);
     return size.QuadPart;
 #else

--- a/src/mio.cpp
+++ b/src/mio.cpp
@@ -22,21 +22,66 @@ bool Path::checkExtension(const std::initializer_list<std::string>& matches) {
 }
 
 time_t Path::getModifiedTime() {
+#ifdef WIN32
+    HANDLE hFile;
+    FILETIME ftModified;
+    hFile = CreateFile(p.string().c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE){
+        throw FSException("Cannot stat mtime (open) " + p.string());
+    }
+
+    if (!GetFileTime(hFile, NULL, NULL, &ftModified)){
+        CloseHandle(hFile);
+        throw FSException("Cannot stat mtime (get time) " + p.string());
+    }
+
+    CloseHandle(hFile);
+    
+    //Get the number of seconds since January 1, 1970 12:00am UTC
+    LARGE_INTEGER li;
+    li.LowPart = ftModified.dwLowDateTime;
+    li.HighPart = ftModified.dwHighDateTime;
+
+    const int64_t UNIX_TIME_START = 0x019DB1DED53E8000; //January 1, 1970 (start of Unix epoch) in "ticks"
+    const int64_t TICKS_PER_SECOND = 10000000; //a tick is 100ns
+
+    //Convert ticks since 1/1/1970 into seconds
+    return (li.QuadPart - UNIX_TIME_START) / TICKS_PER_SECOND;
+#else
     struct stat result;
     if(stat(p.string().c_str(), &result) == 0) {
         return result.st_mtime;
     } else {
-        throw FSException("Cannot stat " + p.string());
+        throw FSException("Cannot stat mtime " + p.string());
     }
+#endif
 }
 
-off_t Path::getSize() {
+std::uintmax_t Path::getSize() {
+#ifdef WIN32
+    HANDLE hFile;
+    FILETIME ftModified;
+    hFile = CreateFile(p.string().c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        throw FSException("Cannot stat size (open) " + p.string());
+    }
+    
+    LARGE_INTEGER size;
+    if (!GetFileSizeEx(hFile, &size)){
+        CloseHandle(hFile);
+        throw FSException("Cannot stat size (getfilesize) " + p.string());
+    }
+    LOGD << size.QuadPart;
+    CloseHandle(hFile);
+    return size.QuadPart;
+#else
     struct stat result;
     if(stat(p.string().c_str(), &result) == 0) {
         return result.st_size;
     } else {
-        throw FSException("Cannot stat " + p.string());
+        throw FSException("Cannot stat size " + p.string());
     }
+#endif
 }
 
 bool Path::hasChildren(const std::vector<std::string> &childPaths) {
@@ -169,7 +214,7 @@ fs::path getCwd(){
     return fs::path(result);
 }
 
-std::string bytesToHuman(off_t bytes){
+std::string bytesToHuman(std::uintmax_t bytes){
     std::ostringstream os;
 
     const char* suffixes[7];
@@ -180,9 +225,10 @@ std::string bytesToHuman(off_t bytes){
     suffixes[4] = "TB";
     suffixes[5] = "PB";
     suffixes[6] = "EB";
-    off_t s = 0;
+    std::uintmax_t s = 0;
 
     double count = bytes;
+
     while (count >= 1024 && s < 7){
         s++;
         count /= 1024;

--- a/src/mio.cpp
+++ b/src/mio.cpp
@@ -25,7 +25,7 @@ time_t Path::getModifiedTime() {
 #ifdef WIN32
     HANDLE hFile;
     FILETIME ftModified;
-    hFile = CreateFile(p.string().c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    hFile = CreateFile(p.string().c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (hFile == INVALID_HANDLE_VALUE){
         throw FSException("Cannot stat mtime (open) " + p.string());
     }
@@ -61,7 +61,7 @@ std::uintmax_t Path::getSize() {
 #ifdef WIN32
     HANDLE hFile;
     FILETIME ftModified;
-    hFile = CreateFile(p.string().c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    hFile = CreateFile(p.string().c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (hFile == INVALID_HANDLE_VALUE) {
         throw FSException("Cannot stat size (open) " + p.string());
     }

--- a/src/mio.h
+++ b/src/mio.h
@@ -30,7 +30,7 @@ public:
     bool checkExtension(const std::initializer_list<std::string>& matches);
 
     time_t getModifiedTime();
-    off_t getSize();
+    std::uintmax_t getSize();
     bool hasChildren(const std::vector<std::string> &childPaths);
     bool isParentOf(const fs::path &childPath);
     int depth();
@@ -52,7 +52,7 @@ fs::path getDataPath(const fs::path &p);
 fs::path getCwd();
 
 // Prints to the provided buffer a nice number of bytes (KB, MB, GB, etc)
-std::string bytesToHuman(off_t bytes);
+std::string bytesToHuman(std::uintmax_t bytes);
 
 }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ add_custom_command(TARGET test POST_BUILD
 )
 endif()
 
-set(EXE_EXT "")
+set(EXE_EXT ".run")
 if (WIN32)
     set(EXE_EXT ".exe")
 endif()
@@ -32,10 +32,7 @@ add_custom_command(TARGET test POST_BUILD
 file(GLOB DATA_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/data"
 )
-if (WIN32)
-	file(COPY ${DATA_FILES} DESTINATION "${CMAKE_BINARY_DIR}")
-else()
-	file(COPY ${DATA_FILES} DESTINATION "${CMAKE_BINARY_DIR}/test")
-endif()
+
+file(COPY ${DATA_FILES} DESTINATION "${CMAKE_BINARY_DIR}")
 
 set_target_properties(test PROPERTIES CXX_STANDARD 17)

--- a/test/fs_test.cpp
+++ b/test/fs_test.cpp
@@ -133,4 +133,15 @@ TEST(bytesToHuman, Normal) {
     EXPECT_EQ(io::bytesToHuman(3372220416), "3.14 GB");
 }
 
+TEST(getModifiedTime, Normal) {
+    // Works on directories
+    EXPECT_TRUE(io::Path(io::getExeFolderPath()).getModifiedTime() > 0);
+
+    // Works on files
+    EXPECT_TRUE(io::Path(io::getDataPath("timezone21.bin")).getModifiedTime() > 0);
+
+
+    
+}
+
 }

--- a/test/fs_test.cpp
+++ b/test/fs_test.cpp
@@ -125,4 +125,12 @@ TEST(pathCheckExtension, Normal) {
 	EXPECT_TRUE(io::Path("/home/test.jpeg.tif").checkExtension({ "tif" }));
 }
 
+TEST(bytesToHuman, Normal) {
+    EXPECT_EQ(io::bytesToHuman(0), "0 B");
+    EXPECT_EQ(io::bytesToHuman(1024), "1 KB");
+    EXPECT_EQ(io::bytesToHuman(1048576), "1 MB");
+
+    EXPECT_EQ(io::bytesToHuman(3372220416), "3.14 GB");
+}
+
 }

--- a/test/fs_test.cpp
+++ b/test/fs_test.cpp
@@ -139,9 +139,6 @@ TEST(getModifiedTime, Normal) {
 
     // Works on files
     EXPECT_TRUE(io::Path(io::getDataPath("timezone21.bin")).getModifiedTime() > 0);
-
-
-    
 }
 
 }


### PR DESCRIPTION
More WIndows shenanigans to stat files when those files are open by another process.

Also fix in bytesToHuman since Windows considers a `off_t` to be a 4 bytes datatype even on 64 bit machines. 