### PR TITLE
Added double quotes to ddbcmd path in bat file

### DIFF
--- a/platform/win32/ddb.bat
+++ b/platform/win32/ddb.bat
@@ -3,4 +3,4 @@
 set DDBBASE=%~dp0
 set PROJ_LIB=%DDBBASE%
 
-%DDBBASE%\ddbcmd.exe %*
+"%DDBBASE%\ddbcmd.exe" %*


### PR DESCRIPTION
This fixes an issue I found when ddb is installed in a folder that contains spaces