### PR TITLE
Fixed relativeTo logic

### DIFF
--- a/src/mio.cpp
+++ b/src/mio.cpp
@@ -116,10 +116,15 @@ int Path::depth() {
 }
 
 Path Path::relativeTo(const fs::path &parent){
+    // Special case where parent == path
+    if (fs::absolute(p) == fs::absolute(parent)) {
+        return fs::path("");
+    }
+
     // Handle special cases where root is "/"
-    // in this case we return the canonical absolute path
-    if (parent == fs::path("/")){
-        return fs::weakly_canonical(fs::absolute(p));
+    // in this case we return the relative canonical absolute path
+    if (parent == parent.root_path() || parent == "/"){
+        return fs::weakly_canonical(fs::absolute(p)).relative_path();
     }
 
     fs::path relPath = fs::relative(fs::weakly_canonical(fs::absolute(p)), fs::weakly_canonical(fs::absolute(parent)));

--- a/test/fs_test.cpp
+++ b/test/fs_test.cpp
@@ -68,10 +68,10 @@ TEST(pathRelativeTo, Normal) {
               io::Path("aaa").generic());
 #ifdef _WIN32
     EXPECT_EQ(io::Path("D:/home/test/aaa").relativeTo("/").generic(),
-              io::Path("D:/home/test/aaa").generic());
+              io::Path("home/test/aaa").generic());
 #else
     EXPECT_EQ(io::Path("/home/test/aaa").relativeTo("/").generic(),
-              io::Path("/home/test/aaa").generic());
+              io::Path("home/test/aaa").generic());
 #endif
     EXPECT_EQ(io::Path("/home/test/aaa/bbb/ccc/../..").relativeTo("/home").generic(),
               io::Path("test/aaa/").generic());
@@ -80,36 +80,40 @@ TEST(pathRelativeTo, Normal) {
 
 #ifdef _WIN32
 	EXPECT_EQ(io::Path("D:/home/test").relativeTo("/").generic(),
-		io::Path("D:/home/test").generic());
+		io::Path("home/test").generic());
+    EXPECT_EQ(io::Path("D:/home/test").relativeTo("D:/").generic(),
+        io::Path("home/test").generic());
+    EXPECT_EQ(io::Path("D:/home/test").relativeTo("D:\\").generic(),
+        io::Path("home/test").generic());
 #else
 	EXPECT_EQ(io::Path("/home/test").relativeTo("/").generic(),
-		io::Path("/home/test").generic());
+		io::Path("home/test").generic());
 #endif
     
 
 #ifdef _WIN32
     EXPECT_EQ(io::Path("D:\\").relativeTo("/").generic(),
-              io::Path("D:\\").generic());
+              io::Path("").generic());
 #else
     EXPECT_EQ(io::Path("/").relativeTo("/").generic(),
-              io::Path("/").generic());
+              io::Path("").generic());
 #endif
 
 #ifdef _WIN32
 	EXPECT_EQ(io::Path("C:\\a\\..").relativeTo("C:").generic(),
-		io::Path("C:\\").generic());
+		io::Path("").generic());
 	EXPECT_EQ(io::Path("C:\\").relativeTo("C:\\a\\..").generic(),
-		io::Path("C:\\").generic());
+		io::Path("").generic());
 #else
     EXPECT_EQ(io::Path("/a/..").relativeTo("/").generic(),
-              io::Path("/").generic());
+              io::Path("").generic());
     EXPECT_EQ(io::Path("/").relativeTo("/a/..").generic(),
-              io::Path("/").generic());
+              io::Path("").generic());
 #endif
 
 #ifdef _WIN32
     EXPECT_EQ(io::Path("C:\\test").relativeTo("/").generic(),
-              io::Path("C:\\test").generic());
+              io::Path("test").generic());
     EXPECT_EQ(io::Path("D:\\test\\..\\aaa").relativeTo("D:\\").generic(),
               io::Path("aaa").generic());
 #endif


### PR DESCRIPTION
There was a fundamental error in relativeTo when handling cases relative to the root path.

This PR fixes that error.