### PR TITLE
Print URL from server instead of computing it during share

### DIFF
--- a/dotnet/DDB.Bindings/DroneDB.cs
+++ b/dotnet/DDB.Bindings/DroneDB.cs
@@ -43,16 +43,23 @@ namespace DDB.Bindings
         [DllImport("ddb", EntryPoint = "DDBAdd")]
         static extern DDBError _Add([MarshalAs(UnmanagedType.LPStr)] string ddbPath, 
                                   [MarshalAs(UnmanagedType.LPArray, ArraySubType=UnmanagedType.LPStr)] string[] paths, 
-                                  int numPaths, bool recursive);
+                                  int numPaths, out IntPtr output, bool recursive);
 
-        public static void Add(string ddbPath, string path, bool recursive = false)
+        public static List<Entry> Add(string ddbPath, string path, bool recursive = false)
         {
-            Add(ddbPath, new[] { path }, recursive);
+            return Add(ddbPath, new[] { path }, recursive);
         }
-        public static void Add(string ddbPath, string[] paths, bool recursive = false)
+        public static List<Entry> Add(string ddbPath, string[] paths, bool recursive = false)
         {
-            if (_Add(ddbPath, paths, paths.Length, recursive) != DDBError.DDBERR_NONE)
+            if (_Add(ddbPath, paths, paths.Length, out var output, recursive) != DDBError.DDBERR_NONE)
                 throw new DDBException(GetLastError());
+
+            var json = Marshal.PtrToStringAnsi(output);
+
+            if (json == null)
+                throw new DDBException("Unable to add");
+
+            return JsonConvert.DeserializeObject<List<Entry>>(json);
         }
 
         [DllImport("ddb", EntryPoint = "DDBRemove")]

--- a/dotnet/DDB.Tests/Tests.cs
+++ b/dotnet/DDB.Tests/Tests.cs
@@ -51,8 +51,12 @@ namespace DDB.Tests
 
             Assert.Throws<DDBException>(() => DroneDB.Add("testAdd", "invalid"));
 
-            DroneDB.Add("testAdd", Path.Join("testAdd", "file.txt"));
-            DroneDB.Add("testAdd", new string[]{ Path.Join("testAdd", "file2.txt"), Path.Join("testAdd", "file3.txt")});
+            var entry = DroneDB.Add("testAdd", Path.Join("testAdd", "file.txt"))[0];
+            Assert.AreEqual(entry.Path, "file.txt");
+            Assert.IsTrue(entry.Hash.Length > 0);
+            
+            var entries = DroneDB.Add("testAdd", new string[]{ Path.Join("testAdd", "file2.txt"), Path.Join("testAdd", "file3.txt")});
+            Assert.AreEqual(entries.Count, 2);
 
             DroneDB.Remove("testAdd", Path.Join("testAdd", "file.txt"));
             Assert.Throws<DDBException>(() => DroneDB.Remove("testAdd", "invalid"));

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -79,10 +79,18 @@ const ddb = {
 
     add: async function(ddbPath, paths, options = {}){
         return new Promise((resolve, reject) => {
-            if (typeof paths === "string") paths = [paths];
-            n.add(ddbPath, paths, options, err => {
+            const isSingle = typeof paths === "string"; 
+            if (isSingle) paths = [paths];
+            
+            n.add(ddbPath, paths, options, (err, entries) => {
                 if (err) reject(err);
-                else resolve(true);                
+                else{
+                    // Return single item
+                    if (isSingle) resolve(entries[0]);
+
+                    // Return entire array
+                    else resolve(entries);
+                }               
             });
         });
     },

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -79,18 +79,11 @@ const ddb = {
 
     add: async function(ddbPath, paths, options = {}){
         return new Promise((resolve, reject) => {
-            const isSingle = typeof paths === "string"; 
-            if (isSingle) paths = [paths];
-            
+            if (typeof paths === "string") paths = [paths];
+
             n.add(ddbPath, paths, options, (err, entries) => {
                 if (err) reject(err);
-                else{
-                    // Return single item
-                    if (isSingle) resolve(entries[0]);
-
-                    // Return entire array
-                    else resolve(entries);
-                }               
+                else return resolve(entries);             
             });
         });
     },

--- a/nodejs/test/dbops.js
+++ b/nodejs/test/dbops.js
@@ -17,7 +17,7 @@ describe('ddbops', function() {
     const imagePath = await t.downloadTestAsset("https://raw.githubusercontent.com/DroneDB/test_data/master/test-datasets/drone_dataset_brighton_beach/DJI_0018.JPG", 
                               "DJI_0018.JPG");
 
-    const addRes = await ddb.add(f, imagePath);
+    const addRes = (await ddb.add(f, imagePath))[0];
     assert.ok(typeof addRes.hash === "string");
     assert.ok(typeof addRes.path === "string");
     assert.ok(typeof addRes.size === "number");

--- a/nodejs/test/dbops.js
+++ b/nodejs/test/dbops.js
@@ -17,7 +17,11 @@ describe('ddbops', function() {
     const imagePath = await t.downloadTestAsset("https://raw.githubusercontent.com/DroneDB/test_data/master/test-datasets/drone_dataset_brighton_beach/DJI_0018.JPG", 
                               "DJI_0018.JPG");
 
-    assert.ok(await ddb.add(f, imagePath));
+    const addRes = await ddb.add(f, imagePath);
+    assert.ok(typeof addRes.hash === "string");
+    assert.ok(typeof addRes.path === "string");
+    assert.ok(typeof addRes.size === "number");
+
     assert.ok(await ddb.remove(f, imagePath));
   });
 });

--- a/src/cmd/add.cpp
+++ b/src/cmd/add.cpp
@@ -37,8 +37,8 @@ void Add::run(cxxopts::ParseResult &opts) {
     auto db = ddb::open(std::string(ddbPath), true);
     ddb::addToIndex(db.get(), ddb::expandPathList(paths,
                                                   recursive,
-                                                  0), [](const ddb::Entry &e){
-        std::cout << "A\t" << e.path << std::endl;
+                                                  0), [](const ddb::Entry &e, bool updated){
+        std::cout << (updated ? "U\t" : "A\t") << e.path << std::endl;
         return true;
     });
 }

--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -224,7 +224,7 @@ void doUpdate(Statement *updateQ, const Entry &e) {
     std::cout << "U\t" << e.path << std::endl;
 }
 
-void addToIndex(Database *db, const std::vector<std::string> &paths) {
+void addToIndex(Database *db, const std::vector<std::string> &paths, std::function<bool(const Entry &entry)> callback) {
     if (paths.size() == 0) return; // Nothing to do
     fs::path directory = rootDirectory(db);
     auto pathList = getIndexPathList(directory, paths, true);
@@ -266,7 +266,7 @@ void addToIndex(Database *db, const std::vector<std::string> &paths) {
                 insertQ->bind(9, e.polygon_geom.toWkt());
 
                 insertQ->execute();
-                std::cout << "A\t" << e.path << std::endl;
+                if (callback != nullptr) if (!callback(e)) return; // cancel
             } else {
                 doUpdate(updateQ.get(), e);
             }

--- a/src/dbops.h
+++ b/src/dbops.h
@@ -21,7 +21,7 @@ DDB_DLL std::vector<std::string> expandPathList(const std::vector<std::string> &
 DDB_DLL bool checkUpdate(Entry &e, const fs::path &p, long long dbMtime, const std::string &dbHash);
 DDB_DLL void doUpdate(Statement *updateQ, const Entry &e);
 
-DDB_DLL void addToIndex(Database *db, const std::vector<std::string> &paths);
+DDB_DLL void addToIndex(Database *db, const std::vector<std::string> &paths, std::function<bool(const Entry &entry)> callback = nullptr);
 DDB_DLL void removeFromIndex(Database *db, const std::vector<std::string> &paths);
 DDB_DLL void syncIndex(Database *db);
 

--- a/src/dbops.h
+++ b/src/dbops.h
@@ -12,6 +12,8 @@
 
 namespace ddb {
 
+typedef std::function<bool(const Entry &e, bool updated)> AddCallback;
+
 DDB_DLL std::unique_ptr<Database> open(const std::string &directory, bool traverseUp);
 DDB_DLL fs::path rootDirectory(Database *db);
 DDB_DLL std::vector<fs::path> getIndexPathList(fs::path rootDirectory, const std::vector<std::string> &paths, bool includeDirs);
@@ -21,7 +23,7 @@ DDB_DLL std::vector<std::string> expandPathList(const std::vector<std::string> &
 DDB_DLL bool checkUpdate(Entry &e, const fs::path &p, long long dbMtime, const std::string &dbHash);
 DDB_DLL void doUpdate(Statement *updateQ, const Entry &e);
 
-DDB_DLL void addToIndex(Database *db, const std::vector<std::string> &paths, std::function<bool(const Entry &entry)> callback = nullptr);
+DDB_DLL void addToIndex(Database *db, const std::vector<std::string> &paths, AddCallback callback = nullptr);
 DDB_DLL void removeFromIndex(Database *db, const std::vector<std::string> &paths);
 DDB_DLL void syncIndex(Database *db);
 

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -11,6 +11,8 @@
 #include "logger.h"
 #include "database.h"
 #include "net.h"
+#include "entry.h"
+#include "json.h"
 #include "exceptions.h"
 #include "utils.h"
 
@@ -85,13 +87,21 @@ void DDBSetLastError(const char *err){
     ddbLastError[254] = '\0';
 }
 
-DDBErr DDBAdd(const char *ddbPath, const char **paths, int numPaths, bool recursive){
+DDBErr DDBAdd(const char *ddbPath, const char **paths, int numPaths, char** output, bool recursive){
 DDB_C_BEGIN
     auto db = ddb::open(std::string(ddbPath), true);
     std::vector<std::string> pathList(paths, paths + numPaths);
+    json outJson = json::array();
     ddb::addToIndex(db.get(), ddb::expandPathList(pathList,
                                                   recursive,
-                                                  0));
+                                                  0), [&outJson](const Entry &e){
+        json j;
+        e.toJSON(j);
+        outJson.push_back(j);
+        return true;
+    });
+
+    utils::copyToPtr(outJson.dump(), output);
 DDB_C_END
 }
 

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -94,7 +94,7 @@ DDB_C_BEGIN
     json outJson = json::array();
     ddb::addToIndex(db.get(), ddb::expandPathList(pathList,
                                                   recursive,
-                                                  0), [&outJson](const Entry &e){
+                                                  0), [&outJson](const Entry &e, bool){
         json j;
         e.toJSON(j);
         outJson.push_back(j);

--- a/src/ddb.h
+++ b/src/ddb.h
@@ -46,9 +46,10 @@ DDB_DLL DDBErr DDBInit(const char *directory, char **outPath = NULL);
  * @param ddbPath path to a DroneDB database (parent of ".ddb")
  * @param paths array of paths to add to index
  * @param numPaths number of paths
+ * @param output pointer to C-string where to store output
  * @param recursive whether to recursively add folders
  * @return DDBERR_NONE on success, an error otherwise */
-DDB_DLL DDBErr DDBAdd(const char *ddbPath, const char **paths, int numPaths, bool recursive = false);
+DDB_DLL DDBErr DDBAdd(const char *ddbPath, const char **paths, int numPaths, char** output, bool recursive = false);
 
 /** Remove one or more files to a DroneDB database
  * @param ddbPath path to a DroneDB database (parent of ".ddb")

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -280,7 +280,7 @@ void calculateFootprint(const SensorSize &sensorSize, const GeoLocation &geo, co
     geom.addPoint(ul.longitude, ul.latitude, groundHeight);
 }
 
-void Entry::toJSON(json &j){
+void Entry::toJSON(json &j) const{
     j["path"] = this->path;
     if (this->hash != "") j["hash"] = this->hash;
     j["type"] = this->type;

--- a/src/entry.h
+++ b/src/entry.h
@@ -33,7 +33,7 @@ struct Entry {
     BasicPointGeometry point_geom;
     BasicPolygonGeometry polygon_geom;
 
-    DDB_DLL void toJSON(json &j);
+    DDB_DLL void toJSON(json &j) const;
     DDB_DLL bool toGeoJSON(json &j, BasicGeometryType type = BasicGeometryType::BGAuto);
     DDB_DLL std::string toString();
 };

--- a/src/shareservice.cpp
+++ b/src/shareservice.cpp
@@ -86,17 +86,9 @@ std::string ShareService::share(const std::vector<std::string> &input, const std
     if (res.status() != 200) handleError(res);
 
     j = res.getJSON();
-    if (!j.contains("objectsCount")) handleError(res);
+    if (!j.contains("url")) handleError(res);
 
-    if (j["objectsCount"].get<unsigned long>() != filePaths.size()){
-        throw RegistryException("Could not upload all files (only " +
-                                std::to_string(j["objectsCount"].get<unsigned long>()) +
-                                " out of " +
-                                std::to_string(filePaths.size()) +
-                                " succeeded)");
-    }
-
-    return reg.getUrl("/r/" + tc.tagWithoutUrl());
+    return reg.getUrl(j["url"]);
 }
 
 void ShareService::handleError(net::Response &res){


### PR DESCRIPTION
After sharing a dataset, uses the return URL value from the registry instead of computing it.

Needs https://github.com/DroneDB/Registry/pull/50 for testing.