### PR TITLE
Build dist target on Windows

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -51,6 +51,12 @@ jobs:
             - name: Run Program Smoke Test
               run: cd build && ddb.bat --debug
               shell: cmd
+            - name: Create Distribution Files
+              shell: cmd
+              run: |
+                cd build
+                cmake --build . --config Release --target dist -- /maxcpucount:14
+                dir
             - name: Upload Distribution Files
               uses: actions/upload-artifact@v2
               with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddb",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Effortless aerial data management and sharing",
   "main": "index.js",
   "directories": {

--- a/scripts/linux_install_script.sh
+++ b/scripts/linux_install_script.sh
@@ -18,7 +18,7 @@ cd "${__dirname}"
 #
 # TODO: this needs to be updated automatically...
 
-LATEST_RELEASE="https://github.com/DroneDB/DroneDB/releases/download/v0.9.3/ddb-0.9.3-linux.tgz"
+LATEST_RELEASE="https://github.com/DroneDB/DroneDB/releases/download/v0.9.4/ddb-0.9.4-linux.tgz"
 
 command_exists() {
 	command -v "$@" > /dev/null 2>&1


### PR DESCRIPTION
For some reason the `ALL_BUILD` target no longer builds the `dist` target. Bho...

This forces a build of the dist target.