### PR TITLE
Change output of info API

### DIFF
--- a/nodejs/js/constants.js
+++ b/nodejs/js/constants.js
@@ -3,5 +3,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
  module.exports = {
-    DEFAULT_REGISTRY: "hub.dronedb.app"
+    DEFAULT_REGISTRY: "testhub1.dronedb.app"
  };

--- a/nodejs/js/index.js
+++ b/nodejs/js/index.js
@@ -8,10 +8,11 @@ const entry = require('./entry');
 const thumbs = require('./thumbs');
 const fetchEntries = require('./fetchEntries');
 const utils = require('./utils');
+const pathutils = require('./pathutils');
 
 const ddb = {
     Tag, Dataset, Registry,
-    entry, utils,
+    entry, utils, pathutils,
     fetchEntries,
     thumbs,
 

--- a/nodejs/js/pathutils.js
+++ b/nodejs/js/pathutils.js
@@ -1,0 +1,17 @@
+const protoRegex = /^(file:\/\/|ddb:\/\/|ddb+unsafe:\/\/)/i;
+
+module.exports = {
+    basename: function(path){
+        const pathWithoutProto = path.replace(protoRegex, "");
+        const name = pathWithoutProto.split(/[\\/]/).pop();
+        if (name) return name;
+        else return pathWithoutProto;
+    },
+
+    join: function(...paths){
+        return paths.map(p => {
+            if (p[p.length - 1] === "/") return p.slice(0, p.length - 1);
+            else return p;
+        }).join("/");
+    }
+}

--- a/src/constants.h
+++ b/src/constants.h
@@ -4,7 +4,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
-#define DEFAULT_REGISTRY "hub.dronedb.app"
+#define DEFAULT_REGISTRY "testhub1.dronedb.app"
 #define DEFAULT_DSM_SERVICE_URL "https://portal.opentopography.org/API/globaldem?demtype=AW3D30&west={west}&south={south}&east={east}&north={north}&outputFormat=GTiff"
 
 #endif // CONSTANTS_H

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -38,8 +38,8 @@ void info(const std::vector<std::string> &input, std::ostream &output,
         Entry e;
         if (parseEntry(fp, "/", e, withHash, stopOnError)){
             // We override e.path because it's relative
-            // But we want the absolute path (in the native path format)
-            e.path = "file://" + fs::absolute(fp).string();
+            // But we want the absolute path (in the unix path format)
+            e.path = "file://" + fs::absolute(fp).generic_string();
 
             if (format == "json"){
                 json j;

--- a/src/userprofile.cpp
+++ b/src/userprofile.cpp
@@ -30,7 +30,9 @@ void UserProfile::createDir(const fs::path &dir){
         if (fs::create_directory(dir)){
             LOGD << "Created " << dir.string();
         }else{
-            throw AppException("Cannot create profile directory: " + dir.string() + ". Check that you have permissions to write.");
+            // Was it created by a competing process?
+            if (!fs::exists(dir)) throw AppException("Cannot create profile directory: " + dir.string() + ". Check that you have permissions to write.");
+            LOGD << "Dir was already created (by another process?): " << dir.string();
         }
     }else{
         LOGD << dir.string() << " exists";


### PR DESCRIPTION
Currently `ddb info` returns a path in native path format (`\` for Windows, `/` for Unix). 

I'm changing it to always return Unix style paths to conform with `file://`, `ddb://` and `ddb+unsafe://` protocol specs.

This might affect Registry.