### PR TITLE
Fixed bug in path calculation for single files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddb",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Effortless aerial data management and sharing",
   "main": "index.js",
   "directories": {

--- a/src/shareservice.cpp
+++ b/src/shareservice.cpp
@@ -47,12 +47,17 @@ std::string ShareService::share(const std::vector<std::string> &input,
     io::Path wd;
     if (cwd.empty()) {
         std::vector<fs::path> paths(input.begin(), input.end());
-        fs::path commonDir = io::commonDirPath(paths);
-        if (commonDir.empty())
-            throw InvalidArgsException(
-                "Cannot share files that don't have a common directory (are "
-                "you trying to share files from different drives?)");
-        wd = io::Path(commonDir);
+
+        if (paths.size() == 1){
+            wd = io::Path(paths.front().parent_path());
+        }else{
+            fs::path commonDir = io::commonDirPath(paths);
+            if (commonDir.empty())
+                throw InvalidArgsException(
+                    "Cannot share files that don't have a common directory (are "
+                    "you trying to share files from different drives?)");
+            wd = io::Path(commonDir);
+        }
     } else {
         wd = io::Path(fs::path(cwd));
     }


### PR DESCRIPTION
Sharing a single path when cwd is empty causes a file to be uploaded with its entire tree path (not the desired behavior).

This fixes it.