### PR TITLE
Add NodeJS bindings for chattr, DroneDB public info via meta

### DIFF
--- a/nodejs/NativeExtension.cc
+++ b/nodejs/NativeExtension.cc
@@ -24,6 +24,7 @@ NAN_MODULE_INIT(InitAll) {
     NAN_EXPORT(target, share);
     NAN_EXPORT(target, list);
     NAN_EXPORT(target, login);
+    NAN_EXPORT(target, chattr);
 
 	DDBRegisterProcess();
 }

--- a/nodejs/js/dataset.js
+++ b/nodejs/js/dataset.js
@@ -57,6 +57,8 @@ module.exports = class Dataset{
     }
 
     async setPublic(flag){
-        return this.registry.postRequest(`${this.baseApi}/chattr`, { public: flag });
+        return this.registry.postRequest(`${this.baseApi}/chattr`, { attrs: JSON.stringify(
+            { public: flag }
+        )});
     }
  };

--- a/nodejs/js/dataset.js
+++ b/nodejs/js/dataset.js
@@ -55,4 +55,8 @@ module.exports = class Dataset{
         if (typeof slug !== "string") throw new Error(`Invalid slug ${slug}`);
         return this.registry.postRequest(`${this.baseApi}/rename`, { slug });
     }
+
+    async setPublic(flag){
+        return this.registry.postRequest(`${this.baseApi}/chattr`, { public: flag });
+    }
  };

--- a/nodejs/js/index.js
+++ b/nodejs/js/index.js
@@ -116,9 +116,9 @@ const ddb = {
 
         this.chattr = async function(ddbPath, attrs = {}){
             return new Promise((resolve, reject) => {
-                n.chattr(ddbPath, attrs, err => {
+                n.chattr(ddbPath, attrs, (err, attrs) => {
                     if (err) reject(err);
-                    else resolve(true);
+                    else resolve(attrs);
                 });
             });
         };

--- a/nodejs/js/index.js
+++ b/nodejs/js/index.js
@@ -114,6 +114,15 @@ const ddb = {
             });
         };
 
+        this.chattr = async function(ddbPath, attrs = {}){
+            return new Promise((resolve, reject) => {
+                n.chattr(ddbPath, attrs, err => {
+                    if (err) reject(err);
+                    else resolve(true);
+                });
+            });
+        };
+
         // Guarantees that paths are expressed with
         // a ddbPath root or are absolute paths
         this._resolvePaths = function(ddbPath, paths){

--- a/nodejs/ne_dbops.cc
+++ b/nodejs/ne_dbops.cc
@@ -212,7 +212,7 @@ class ChattrWorker : public Nan::AsyncWorker {
   ~ChattrWorker() {}
 
   void Execute () {
-    if (DDBChattr(ddbPath.c_str(), attrsJson.c_str()) != DDBERR_NONE){
+    if (DDBChattr(ddbPath.c_str(), attrsJson.c_str(), &output) != DDBERR_NONE){
         SetErrorMessage(DDBGetLastError());
     }
   }
@@ -222,16 +222,18 @@ class ChattrWorker : public Nan::AsyncWorker {
 
      Nan::JSON json;
      v8::Local<v8::Value> argv[] = {
-         Nan::Null()
+         Nan::Null(),
+         json.Parse(Nan::New<v8::String>(output).ToLocalChecked()).ToLocalChecked()
      };
 
-     callback->Call(1, argv, async_resource);
+     callback->Call(2, argv, async_resource);
    }
 
  private:
     std::string ddbPath;
     std::string attrsJson;
 
+    char *output;
 };
 
 NAN_METHOD(chattr) {

--- a/nodejs/ne_dbops.cc
+++ b/nodejs/ne_dbops.cc
@@ -202,3 +202,54 @@ NAN_METHOD(list) {
 
     Nan::AsyncQueueWorker(new ListWorker(callback, ddbPath, in, recursive, maxRecursionDepth));
 }
+
+
+class ChattrWorker : public Nan::AsyncWorker {
+ public:
+  ChattrWorker(Nan::Callback *callback, const std::string &ddbPath, const std::string &attrsJson)
+    : AsyncWorker(callback, "nan:ChattrWorker"),
+      ddbPath(ddbPath), attrsJson(attrsJson){}
+  ~ChattrWorker() {}
+
+  void Execute () {
+    if (DDBChattr(ddbPath.c_str(), attrsJson.c_str()) != DDBERR_NONE){
+        SetErrorMessage(DDBGetLastError());
+    }
+  }
+
+  void HandleOKCallback () {
+     Nan::HandleScope scope;
+
+     Nan::JSON json;
+     v8::Local<v8::Value> argv[] = {
+         Nan::Null()
+     };
+
+     callback->Call(1, argv, async_resource);
+   }
+
+ private:
+    std::string ddbPath;
+    std::string attrsJson;
+
+};
+
+NAN_METHOD(chattr) {
+    ASSERT_NUM_PARAMS(3);
+
+    BIND_STRING_PARAM(ddbPath, 0);
+    BIND_OBJECT_PARAM(attrs, 1);
+
+    Nan::JSON NanJSON;
+    Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(attrs);
+    std::string attrsJson;
+
+    if (!result.IsEmpty()) {
+        Nan::Utf8String str(result.ToLocalChecked().As<v8::String>());
+        attrsJson = std::string(*str);
+    }
+
+    BIND_FUNCTION_PARAM(callback, 2);
+
+    Nan::AsyncQueueWorker(new ChattrWorker(callback, ddbPath, attrsJson));
+}

--- a/nodejs/ne_dbops.h
+++ b/nodejs/ne_dbops.h
@@ -10,6 +10,7 @@ NAN_METHOD(init);
 NAN_METHOD(add);
 NAN_METHOD(remove);
 NAN_METHOD(list);
+NAN_METHOD(chattr);
 
 
 #endif

--- a/nodejs/test/dbops.js
+++ b/nodejs/test/dbops.js
@@ -37,7 +37,9 @@ describe('ddbops', function() {
         let info = await ddb.info(ddbPath);
         assert.equal(info[0].meta.public, false);
 
-        await ddb.chattr(ddbPath, { public: true });
+        const attrs = await ddb.chattr(ddbPath, { public: true });
+        assert.equal(attrs.public, true);
+
         info = await ddb.info(ddbPath);
         assert.equal(info[0].meta.public, true);
 

--- a/nodejs/test/dbops.js
+++ b/nodejs/test/dbops.js
@@ -9,7 +9,7 @@ const path = require('path');
 
 describe('ddbops', function() {
     it('should be able to call init(), add() and remove()', async function() {
-        this.timeout(4000);
+        this.timeout(8000);
         const t = new TestArea("init", true);
         const f = t.getFolder(".");
         const ddbPath = await ddb.init(f);
@@ -28,7 +28,7 @@ describe('ddbops', function() {
     });
 
     it ('should be able to call chattr()', async function(){
-        this.timeout(4000);
+        this.timeout(8000);
 
         const t = new TestArea("init", true);
         const f = t.getFolder(".");

--- a/nodejs/test/dbops.js
+++ b/nodejs/test/dbops.js
@@ -5,6 +5,7 @@ const ddb = require('../');
 const assert = require('assert');
 const { TestArea } = require('./helpers');
 const fs = require('fs');
+const path = require('path');
 
 describe('ddbops', function() {
     it('should be able to call init(), add() and remove()', async function() {
@@ -25,4 +26,21 @@ describe('ddbops', function() {
 
         assert.ok(await ddb.remove(f, imagePath));
     });
+
+    it ('should be able to call chattr()', async function(){
+        this.timeout(4000);
+
+        const t = new TestArea("init", true);
+        const f = t.getFolder(".");
+        const ddbPath = path.join(await ddb.init(f), "..");
+
+        let info = await ddb.info(ddbPath);
+        assert.equal(info[0].meta.public, false);
+
+        await ddb.chattr(ddbPath, { public: true });
+        info = await ddb.info(ddbPath);
+        assert.equal(info[0].meta.public, true);
+
+        await assert.rejects(ddb.chattr(ddbPath, { invalid: "123" }));        
+    })
 });

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -63,6 +63,16 @@ bool Database::isPublic() const{
     else return false;
 }
 
+void Database::chattr(json attrs){
+    for (auto& el : attrs.items()) {
+        if (el.key() == "public" && el.value().is_boolean()){
+            this->setBoolAttribute("public", el.value());
+        }else{
+            throw InvalidArgsException("Invalid attribute " + el.key());
+        }
+    }
+}
+
 json Database::getAttributes() const{
     json j;
     j["public"] = this->getBoolAttribute("public");

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -75,7 +75,7 @@ void Database::chattr(json attrs){
 
 json Database::getAttributes() const{
     json j;
-    j["public"] = this->getBoolAttribute("public");
+    j["public"] = this->isPublic();
     return j;
 }
 

--- a/src/database.h
+++ b/src/database.h
@@ -30,6 +30,7 @@ class Database : public SqliteDatabase {
 
       DDB_DLL void setPublic(bool isPublic);
       DDB_DLL bool isPublic() const;
+      DDB_DLL void chattr(json attrs);
 
       DDB_DLL json getAttributes() const;
 };

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -308,7 +308,6 @@ DDBErr DDBChattr(const char *ddbPath, const char *attrsJson){
 DDB_C_BEGIN
     const auto db = ddb::open(std::string(ddbPath), true);
     json j = json::parse(attrsJson);
-    std::cerr << "AH!";
     db->chattr(j);
 DDB_C_END
 }

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -304,10 +304,12 @@ DDB_DLL DDBErr DDBStatus(const char* ddbPath, char** output) {
 
 }
 
-DDBErr DDBChattr(const char *ddbPath, const char *attrsJson){
+DDBErr DDBChattr(const char *ddbPath, const char *attrsJson, char **output){
 DDB_C_BEGIN
     const auto db = ddb::open(std::string(ddbPath), true);
     json j = json::parse(attrsJson);
     db->chattr(j);
+    utils::copyToPtr(db->getAttributes().dump(), output);
+
 DDB_C_END
 }

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -303,3 +303,12 @@ DDB_DLL DDBErr DDBStatus(const char* ddbPath, char** output) {
   DDB_C_END
 
 }
+
+DDBErr DDBChattr(const char *ddbPath, const char *attrsJson){
+DDB_C_BEGIN
+    const auto db = ddb::open(std::string(ddbPath), true);
+    json j = json::parse(attrsJson);
+    std::cerr << "AH!";
+    db->chattr(j);
+DDB_C_END
+}

--- a/src/ddb.h
+++ b/src/ddb.h
@@ -109,6 +109,12 @@ DDB_DLL DDBErr DDBClearPasswords(const char* ddbPath);
  * @return DDBERR_NONE on success, an error otherwise */
 DDB_DLL DDBErr DDBStatus(const char* ddbPath, char **output);
 
+/** Show differences between index and filesystem
+ * @param ddbPath path to a DroneDB database (parent of ".ddb")
+ * @param attrsJson array of object attributes as a JSON string
+ * @return DDBERR_NONE on success, an error otherwise */
+DDB_DLL DDBErr DDBChattr(const char* ddbPath, const char *attrsJson);
+
 
 #ifdef __cplusplus
 }

--- a/src/ddb.h
+++ b/src/ddb.h
@@ -112,8 +112,9 @@ DDB_DLL DDBErr DDBStatus(const char* ddbPath, char **output);
 /** Show differences between index and filesystem
  * @param ddbPath path to a DroneDB database (parent of ".ddb")
  * @param attrsJson array of object attributes as a JSON string
+ * @param output pointer to C-string where to store output (JSON). Output contains the new DDB metadata.
  * @return DDBERR_NONE on success, an error otherwise */
-DDB_DLL DDBErr DDBChattr(const char* ddbPath, const char *attrsJson);
+DDB_DLL DDBErr DDBChattr(const char* ddbPath, const char *attrsJson, char **output);
 
 
 #ifdef __cplusplus

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 #include <exiv2/exiv2.hpp>
+#include "dbops.h"
 #include "entry.h"
 #include "mio.h"
 #include "ogr_srs_api.h"
@@ -31,7 +32,7 @@ bool parseEntry(const fs::path &path, const fs::path &rootDirectory, Entry &entr
         // Check for DroneDB dir
         try{
             if (fs::exists(path / ".ddb" / "dbase.sqlite")){
-                entry.type = EntryType::DroneDB;
+                parseDroneDBEntry(path, entry);
             }
         }catch(const fs::filesystem_error &e){
             LOGD << "Cannot check " << path.string() << " .ddb presence: " << e.what();
@@ -381,26 +382,18 @@ void parsePoint(BasicGeometry* point_geom, nlohmann::basic_json<>::value_type co
 	point_geom->addPoint(x, y, z);
 }
 
-void loadPointGeom(BasicPointGeometry *point_geom, const std::string& text)
-{
-    if (text.empty()) 
-        throw DBException("text is empty");
+void loadPointGeom(BasicPointGeometry *point_geom, const std::string& text){
+    if (text.empty()) throw DBException("text is empty");
 	
-	if (point_geom == nullptr)
-        throw DBException("point_geom is null");
+    if (point_geom == nullptr) throw DBException("point_geom is null");
 	
     const auto j = json::parse(text);
 	
     // {"type":"Point","coordinates":[-91.99456000000001,46.842607,198.31]}
 
-	if (!j.contains("type"))
-        throw DBException("Missing 'type' field");
-    	
-	if (j["type"].get<std::string>() != "Point")
-        throw DBException(utils::stringFormat("Cannot parse point_geom field: expected Point type but got: %s", j["type"].dump()));
-
-    if (!j.contains("coordinates"))
-        throw DBException("Missing 'coordinates' field");
+    if (!j.contains("type")) throw DBException("Missing 'type' field");
+    if (j["type"].get<std::string>() != "Point") throw DBException(utils::stringFormat("Cannot parse point_geom field: expected Point type but got: %s", j["type"].dump()));
+    if (!j.contains("coordinates")) throw DBException("Missing 'coordinates' field");
 
 	auto coordinates = j["coordinates"];
 
@@ -408,70 +401,45 @@ void loadPointGeom(BasicPointGeometry *point_geom, const std::string& text)
 
 }
 
-void loadPolygonGeom(BasicPolygonGeometry *polygon_geom, const std::string& text)
-{
-	/*
-	{
-	    "type": "Polygon",
-	    "coordinates": [
-			[
-				[-91.99469773385999, 46.84296499722999, 158.5100007629],
-				[-91.99507616866998, 46.84271189348, 158.5100007629],
-				[-91.9944204067, 46.84225026546, 158.5100007629],
-				[-91.99404197212, 46.84250336707, 158.5100007629],
-				[-91.99469773385999, 46.84296499722999, 158.5100007629]
-			]
-		]
-	}	  
-	 */
-
-
-    if (text.empty())
-        throw DBException("text is empty");
-
-    if (polygon_geom == nullptr)
-        throw DBException("polygon_geom is null");
+void loadPolygonGeom(BasicPolygonGeometry *polygon_geom, const std::string& text){
+    if (text.empty()) throw DBException("text is empty");
+    if (polygon_geom == nullptr) throw DBException("polygon_geom is null");
 
     const auto j = json::parse(text);
 
-    if (!j.contains("type"))
-        throw DBException("Missing 'type' field");
-
-    if (j["type"].get<std::string>() != "Polygon")
-        throw DBException(utils::stringFormat("Cannot parse polygon_geom field: expected Polygon type but got: %s", j["type"].dump()));
-
-    if (!j.contains("coordinates"))
-        throw DBException("Missing 'coordinates' field");
+    if (!j.contains("type")) throw DBException("Missing 'type' field");
+    if (j["type"].get<std::string>() != "Polygon") throw DBException(utils::stringFormat("Cannot parse polygon_geom field: expected Polygon type but got: %s", j["type"].dump()));
+    if (!j.contains("coordinates")) throw DBException("Missing 'coordinates' field");
 
     auto coordinates = j["coordinates"];
 
-    if (coordinates.empty())
-        throw DBException("Empty 'coordinates' field");
-
-    if (coordinates.size() != 1)
-        throw DBException(utils::stringFormat("Expected 1 coordinates but got ", coordinates.size()));
+    if (coordinates.empty()) throw DBException("Empty 'coordinates' field");
+    if (coordinates.size() != 1) throw DBException(utils::stringFormat("Expected 1 coordinates but got ", coordinates.size()));
 
     coordinates = coordinates[0];
 
-    if (coordinates.size() == 0)
-        throw DBException("Expected coordinates but got 0");
+    if (coordinates.size() == 0) throw DBException("Expected coordinates but got 0");
 
-	for (const auto coord : coordinates)
-	{
+    for (const auto &coord : coordinates){
         parsePoint(polygon_geom, coord);
 	}
-	
-    //const auto x = coordinates[0].get<double>();
-    //const auto y = coordinates[1].get<double>();
-    //const auto z = coordinates[2].get<double>();
+}
 
-    //LOGD << "Parsed point: (" << x << "; " << y << "; " << z << ")";
+void parseDroneDBEntry(const fs::path &ddbPath, Entry &entry){
+    try{
+        const auto db = ddb::open(ddbPath, false);
 
-    //
+        // The size of the database is the sum of all entries' sizes
+        auto q = db->query("SELECT SUM(size) FROM entries");
+        if (q->fetch()){
+            entry.size = q->getInt64(0);
+        }
 
-
-	
-	
+        entry.meta["public"] = db->isPublic();
+    }catch(AppException &e){
+        LOGD << e.what();
+        entry.type = EntryType::Directory;
+    }
 }
 
 

--- a/src/entry.h
+++ b/src/entry.h
@@ -81,7 +81,7 @@ struct Entry {
 DDB_DLL bool parseEntry(const fs::path &path, const fs::path &rootDirectory, Entry &entry, bool wishHash = true, bool stopOnError = true);
 DDB_DLL Geographic2D getRasterCoordinate(OGRCoordinateTransformationH hTransform, double *geotransform, double x, double y);
 DDB_DLL void calculateFootprint(const SensorSize &sensorSize, const GeoLocation &geo, const Focal &focal, const CameraOrientation &cameraOri, double relAltitude, BasicGeometry &geom);
-
+DDB_DLL void parseDroneDBEntry(const fs::path &ddbPath, Entry &entry);
 
 
 }


### PR DESCRIPTION
Also adds DroneDB entry size calculation, misc cleanup.

Now you can issue:

```
[piero:/data/test] $ ddb info . --format json
[{"depth":1,"meta":{"public":true},"mtime":1606227570,"path":"file:///data/test/.","size":4024770,"type":1}]
```

This is relevant to Registry; public visibility flag should be stored on ddb, not on Registry's tables.