### PR TITLE
Don't crash process when reading Unicode files on Windows

### DIFF
--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-#include <codecvt>
 #include "dbops.h"
 #include "entry_types.h"
 #include "exif.h"

--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+#include <codecvt>
 #include "dbops.h"
 #include "entry_types.h"
 #include "exif.h"
@@ -141,7 +142,7 @@ std::vector<fs::path> getPathList(const std::vector<std::string> &paths, bool in
 
                     // Ignore system files on Windows
                     #ifdef WIN32
-                    DWORD attrs = GetFileAttributes(rp.string().c_str());
+                    DWORD attrs = GetFileAttributesW(rp.wstring().c_str());
                     if (attrs & FILE_ATTRIBUTE_HIDDEN || attrs & FILE_ATTRIBUTE_SYSTEM) {
                         i.disable_recursion_pending();
                         continue;

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -42,6 +42,19 @@ void DDBRegisterProcess(bool verbose) {
 	setenv("PROJ_LIB", projPaths.c_str(), 1);
 #endif
 
+#if !defined(WIN32) && !defined(MAC_OSX)
+    try {
+        std::locale("");  // Raises a runtime error if current locale is invalid
+    } catch (const std::runtime_error&) {
+        setenv("LC_ALL", "C", 1);
+    }
+#endif
+
+#ifdef WIN32
+	// Allow path.string() calls to work with Unicode filenames
+    std::setlocale(LC_CTYPE, "en_US.UTF8");
+#endif
+
 	// Gets the environment variable to enable logging to file
 	const auto logToFile = std::getenv(DDB_LOG_ENV) != nullptr;
 

--- a/src/mio.cpp
+++ b/src/mio.cpp
@@ -25,7 +25,7 @@ time_t Path::getModifiedTime() {
 #ifdef WIN32
     HANDLE hFile;
     FILETIME ftModified;
-    hFile = CreateFile(p.string().c_str(), 0, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    hFile = CreateFileW(p.wstring().c_str(), 0, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (hFile == INVALID_HANDLE_VALUE){
         throw FSException("Cannot stat mtime (open) " + p.string() + " (errcode: " + std::to_string(GetLastError()) + ")");
     }
@@ -60,7 +60,7 @@ time_t Path::getModifiedTime() {
 std::uintmax_t Path::getSize() {
 #ifdef WIN32
     HANDLE hFile;
-    hFile = CreateFile(p.string().c_str(), 0, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    hFile = CreateFileW(p.wstring().c_str(), 0, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (hFile == INVALID_HANDLE_VALUE) {
         throw FSException("Cannot stat size (open) " + p.string() + " (errcode: " + std::to_string(GetLastError()));
     }


### PR DESCRIPTION
Closes #141 

At least the process doesn't crash, but unicode characters are replaced with `?` (not good long term).

