### PR TITLE
Support for tiling geoprojectable geoimages

### DIFF
--- a/src/cmd/tile.cpp
+++ b/src/cmd/tile.cpp
@@ -51,7 +51,7 @@ void Tile::run(cxxopts::ParseResult &opts) {
     auto tileSize = opts["size"].as<int>();
 
     fs::path geotiff = ddb::TilerHelper::toGeoTIFF(input, tileSize, true);
-    ddb::Tiler tiler(geotiff, output, tileSize, tms);
+    ddb::Tiler tiler(geotiff.string(), output, tileSize, tms);
     ddb::TilerHelper::runTiler(tiler, std::cout, format, z, x, y);    
 }
 

--- a/src/cmd/tile.cpp
+++ b/src/cmd/tile.cpp
@@ -13,7 +13,7 @@ void Tile::setOptions(cxxopts::Options &opts) {
     // clang-format off
     opts
     .positional_help("[args]")
-    .custom_help("tile geo.tif [output directory]")
+    .custom_help("tile [geo.tif | image.jpg] [output directory]")
     .add_options()
     ("i,input", "File to tile", cxxopts::value<std::string>())
     ("o,output", "Output directory where to store tiles", cxxopts::value<std::string>()->default_value("{filename}_tiles/"))
@@ -28,7 +28,7 @@ void Tile::setOptions(cxxopts::Options &opts) {
 }
 
 std::string Tile::description() {
-    return "Generate tiles for GeoTIFFs";
+    return "Generate tiles for GeoTIFFs and GeoImages";
 }
 
 void Tile::run(cxxopts::ParseResult &opts) {
@@ -50,8 +50,9 @@ void Tile::run(cxxopts::ParseResult &opts) {
     auto y = opts["y"].as<std::string>();
     auto tileSize = opts["size"].as<int>();
 
-    ddb::Tiler tiler(input, output, tileSize, tms);
-    ddb::TilerHelper::runTiler(tiler, std::cout, format, z, x, y);
+    fs::path geotiff = ddb::TilerHelper::toGeoTIFF(input, tileSize, true);
+    ddb::Tiler tiler(geotiff, output, tileSize, tms);
+    ddb::TilerHelper::runTiler(tiler, std::cout, format, z, x, y);    
 }
 
 }

--- a/src/entry.h
+++ b/src/entry.h
@@ -78,11 +78,20 @@ struct Entry {
 
 };
 
+/** Parse an entry
+ * @param path path to file
+ * @param rootDirectory root directory from which to compute relative path
+ * @param entry reference to output Entry object
+ * @param withHash whether to compute the hash of the file (slow)
+ */
 DDB_DLL void parseEntry(const fs::path &path, const fs::path &rootDirectory, Entry &entry, bool wishHash = true);
 DDB_DLL Geographic2D getRasterCoordinate(OGRCoordinateTransformationH hTransform, double *geotransform, double x, double y);
 DDB_DLL void calculateFootprint(const SensorSize &sensorSize, const GeoLocation &geo, const Focal &focal, const CameraOrientation &cameraOri, double relAltitude, BasicGeometry &geom);
 DDB_DLL void parseDroneDBEntry(const fs::path &ddbPath, Entry &entry);
 
+/** Identify whether a file is an Image, GeoImage, Georaster or something else
+ * as quickly as possible. Does not fingerprint for other types. */
+DDB_DLL EntryType fingerprint(const fs::path &path);
 
 }
 

--- a/src/geoproject.h
+++ b/src/geoproject.h
@@ -9,7 +9,7 @@
 
 namespace ddb {
 
-DDB_DLL void geoProject(const std::vector<std::string> &images, const std::string &output, const std::string &outsize = "");
+DDB_DLL void geoProject(const std::vector<std::string> &images, const std::string &output, const std::string &outsize = "", bool stopOnError = false);
 
 }
 

--- a/src/tiler.cpp
+++ b/src/tiler.cpp
@@ -10,6 +10,8 @@
 #include "hash.h"
 #include "mio.h"
 #include "userprofile.h"
+#include "entry.h"
+#include "geoproject.h"
 
 namespace ddb{
 
@@ -341,18 +343,18 @@ BoundingBox<int> TilerHelper::parseZRange(const std::string &zRange){
     return r;
 }
 
-fs::path TilerHelper::getCacheFolderName(const fs::path &geotiffPath, time_t modifiedTime, int tileSize){
+fs::path TilerHelper::getCacheFolderName(const fs::path &tileablePath, time_t modifiedTime, int tileSize){
     std::ostringstream os;
-    os << geotiffPath.string() << "*" << modifiedTime << "*" << tileSize;
+    os << tileablePath.string() << "*" << modifiedTime << "*" << tileSize;
     return Hash::strCRC64(os.str());
 }
 
-fs::path TilerHelper::getFromUserCache(const fs::path &geotiffPath, int tz, int tx, int ty, int tileSize, bool tms, bool forceRecreate){
+fs::path TilerHelper::getFromUserCache(const fs::path &tileablePath, int tz, int tx, int ty, int tileSize, bool tms, bool forceRecreate){
     if (std::rand() % 1000 == 0) cleanupUserCache();
-    if (!fs::exists(geotiffPath)) throw FSException(geotiffPath.string() + " does not exist");
+    if (!fs::exists(tileablePath)) throw FSException(tileablePath.string() + " does not exist");
 
-    time_t modifiedTime = io::Path(geotiffPath).getModifiedTime();
-    fs::path tileCacheFolder = UserProfile::get()->getTilesDir() / getCacheFolderName(geotiffPath, modifiedTime, tileSize);
+    time_t modifiedTime = io::Path(tileablePath).getModifiedTime();
+    fs::path tileCacheFolder = UserProfile::get()->getTilesDir() / getCacheFolderName(tileablePath, modifiedTime, tileSize);
     fs::path outputFile = tileCacheFolder / std::to_string(tz) / std::to_string(tx) / (std::to_string(ty) + ".png");
 
     // Cache hit
@@ -360,8 +362,44 @@ fs::path TilerHelper::getFromUserCache(const fs::path &geotiffPath, int tz, int 
         return outputFile;
     }
 
-    Tiler t(geotiffPath.string(), tileCacheFolder.string(), tileSize, tms);
+    fs::path fileToTile = toGeoTIFF(tileablePath, tileSize, forceRecreate, (tileCacheFolder / "geoprojected.tif"));
+    Tiler t(fileToTile.string(), tileCacheFolder.string(), tileSize, tms);
     return t.tile(tz, tx, ty);
+}
+
+fs::path TilerHelper::toGeoTIFF(const fs::path &tileablePath, int tileSize, bool forceRecreate, const fs::path &outputGeotiff){
+    EntryType type = fingerprint(tileablePath);
+
+    if (type == EntryType::GeoRaster){
+        // Georasters can be tiled directly
+        return tileablePath;
+    }else{
+        fs::path outputPath = outputGeotiff;
+
+        if (outputGeotiff.empty()){
+            // Store in user cache if user doesn't specify a preference
+            if (std::rand() % 1000 == 0) cleanupUserCache();
+            time_t modifiedTime = io::Path(tileablePath).getModifiedTime();
+            fs::path tileCacheFolder = UserProfile::get()->getTilesDir() / getCacheFolderName(tileablePath, modifiedTime, tileSize);
+
+            if (!fs::exists(tileCacheFolder)){
+                // Try to create
+                if (!fs::create_directories(tileCacheFolder)){
+                    throw FSException(tileCacheFolder.string() + " is not a valid directory (cannot create it).");
+                }
+            }
+
+            outputPath = tileCacheFolder / "geoprojected.tif";
+        }
+
+
+        // We need to (attempt) to geoproject the file first
+        if (!fs::exists(outputPath) || forceRecreate){
+            ddb::geoProject({ tileablePath }, outputPath, "100%", true);
+        }
+
+        return outputPath;
+    }
 }
 
 void TilerHelper::cleanupUserCache(){

--- a/src/tiler.cpp
+++ b/src/tiler.cpp
@@ -395,8 +395,7 @@ fs::path TilerHelper::toGeoTIFF(const fs::path &tileablePath, int tileSize, bool
 
         // We need to (attempt) to geoproject the file first
         if (!fs::exists(outputPath) || forceRecreate){
-            std::vector<std::string> input = { tileablePath };
-            ddb::geoProject(input, outputPath.string(), "100%", true);
+            ddb::geoProject({tileablePath.string()}, outputPath.string(), "100%", true);
         }
 
         return outputPath;

--- a/src/tiler.cpp
+++ b/src/tiler.cpp
@@ -395,7 +395,8 @@ fs::path TilerHelper::toGeoTIFF(const fs::path &tileablePath, int tileSize, bool
 
         // We need to (attempt) to geoproject the file first
         if (!fs::exists(outputPath) || forceRecreate){
-            ddb::geoProject({ tileablePath }, outputPath, "100%", true);
+            std::vector<std::string> input = { tileablePath };
+            ddb::geoProject(input, outputPath, "100%", true);
         }
 
         return outputPath;

--- a/src/tiler.cpp
+++ b/src/tiler.cpp
@@ -396,7 +396,7 @@ fs::path TilerHelper::toGeoTIFF(const fs::path &tileablePath, int tileSize, bool
         // We need to (attempt) to geoproject the file first
         if (!fs::exists(outputPath) || forceRecreate){
             std::vector<std::string> input = { tileablePath };
-            ddb::geoProject(input, outputPath, "100%", true);
+            ddb::geoProject(input, outputPath.string(), "100%", true);
         }
 
         return outputPath;

--- a/src/tiler.h
+++ b/src/tiler.h
@@ -132,13 +132,17 @@ class TilerHelper{
     static BoundingBox<int> parseZRange(const std::string &zRange);
 
     // Where to store local cache tiles
-    static fs::path getCacheFolderName(const fs::path &geotiffPath, time_t modifiedTime, int tileSize);
+    static fs::path getCacheFolderName(const fs::path &tileablePath, time_t modifiedTime, int tileSize);
 
 public:
     DDB_DLL static void runTiler(Tiler &tiler, std::ostream &output = std::cout, const std::string &format = "text", const std::string &zRange = "auto", const std::string &x = "auto", const std::string &y = "auto");
 
     // Get a single tile from user cache
-    DDB_DLL static fs::path getFromUserCache(const fs::path &geotiffPath, int tz, int tx, int ty, int tileSize, bool tms, bool forceRecreate);
+    DDB_DLL static fs::path getFromUserCache(const fs::path &tileablePath, int tz, int tx, int ty, int tileSize, bool tms, bool forceRecreate);
+
+    // Prepare a tileable file for tiling (if needed)
+    // for example, geoimages that can be tiled are first geoprojected
+    DDB_DLL static fs::path toGeoTIFF(const fs::path &tileablePath, int tileSize, bool forceRecreate, const fs::path &outputGeotiff = "");
 
     DDB_DLL static void cleanupUserCache();
 };


### PR DESCRIPTION
We can now generate tiles on the fly for geoprojectable geoimages using a unified tiling API.

![image](https://user-images.githubusercontent.com/1951843/103700082-ecf04480-4f71-11eb-9ddc-4117d0620ad2.png)

This allows us to display image footprints directly on the map.