### PR TITLE
Fix geoproj batch processing

### DIFF
--- a/src/cmd/geoproj.cpp
+++ b/src/cmd/geoproj.cpp
@@ -36,7 +36,10 @@ void GeoProj::run(cxxopts::ParseResult &opts) {
     auto output = opts["output"].as<std::string>();
     auto outsize = opts["size"].as<std::string>();
 
-    std::cout << "W\t" << ddb::geoProject(images, output, outsize);
+    ddb::geoProject(images, output, outsize, false, [](const std::string &imageWritten){
+        std::cout << "W\t" << imageWritten << std::endl;
+        return true;
+    });
 }
 
 }

--- a/src/geoproject.cpp
+++ b/src/geoproject.cpp
@@ -9,11 +9,15 @@
 
 namespace ddb {
 
-std::string geoProject(const std::vector<std::string> &images, const std::string &output, const std::string &outsize, bool stopOnError){
+void geoProject(const std::vector<std::string> &images, const std::string &output, const std::string &outsize, bool stopOnError, const GeoProjectCallback &callback){
     bool isDirectory = fs::is_directory(output);
     bool outputToDir = images.size() > 1 || isDirectory;
     if (outputToDir){
         if (!isDirectory){
+            // Bad input?
+            if (fs::is_regular_file(output)){
+                throw FSException(output + " is a file. (Did you switch the input and output parameters?)");
+            }
             if (!fs::create_directories(output)){
                 throw FSException(output + " is not a valid directory (cannot create it).");
             }
@@ -144,7 +148,9 @@ std::string geoProject(const std::vector<std::string> &images, const std::string
         GDALClose(hDstDataset);
         GDALClose(hWrpDataset);
 
-        return outFile;
+        if (callback){
+            if (!callback(outFile)) return;
+        }
     }
 }
 

--- a/src/geoproject.h
+++ b/src/geoproject.h
@@ -9,7 +9,10 @@
 
 namespace ddb {
 
-DDB_DLL std::string geoProject(const std::vector<std::string> &images, const std::string &output, const std::string &outsize = "", bool stopOnError = false);
+typedef std::function<bool(const std::string &imageWritten)>
+    GeoProjectCallback;
+
+DDB_DLL void geoProject(const std::vector<std::string> &images, const std::string &output, const std::string &outsize = "", bool stopOnError = false, const GeoProjectCallback &callback = nullptr);
 
 }
 


### PR DESCRIPTION
The `geoproj` command wasn't able to batch-process multiple files due to a bug introduced with https://github.com/DroneDB/DroneDB/commit/a4f2697ac42d0a82fcbf9d0339aad4052f8e9176