### PR TITLE
File lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,10 @@ endif()
 
 set(OUTPUT_DIST_FILE "${PROJECT_NAME}-${APP_VERSION}-${PLATFORM_NAME}.${OUTPUT_DIST_EXT}")
 set(SUPPORT_FILES "proj.db" "sensor_data.sqlite" "timezone21.bin" "curl-ca-bundle.crt")
+if (WIN32)
+    # Linux usually comes with a zoneinfo database already
+    list(APPEND SUPPORT_FILES "zoneinfo")
+endif()
 
 set(DIST_FILES "")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ if (WIN32)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING
@@ -95,15 +94,13 @@ find_package(GDAL REQUIRED)
 find_package(CURL REQUIRED)
 find_package(SpatiaLite REQUIRED)
 find_package(Sqlite3 REQUIRED)
-find_package(Threads REQUIRED)
 include_directories(${GDAL_INCLUDE_DIR})
 
 if (NOT WIN32)
     set(STDPPFS_LIBRARY stdc++fs)
-    set(THREADS_LIBRARY Threads::Threads)
 endif()
 
-set(LINK_LIBRARIES ${SPATIALITE_LIBRARY} ${SQLITE3_LIBRARY} ${STDPPFS_LIBRARY} exiv2lib ${GDAL_LIBRARY} ${CURL_LIBRARY} ${THREADS_LIBRARY})
+set(LINK_LIBRARIES ${SPATIALITE_LIBRARY} ${SQLITE3_LIBRARY} ${STDPPFS_LIBRARY} exiv2lib ${GDAL_LIBRARY} ${CURL_LIBRARY})
 set(CMD_SRC_LIST ${CMAKE_CURRENT_SOURCE_DIR}/src/cmd/main.cpp)
 
 add_subdirectory("src")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if (WIN32)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING
@@ -94,13 +95,15 @@ find_package(GDAL REQUIRED)
 find_package(CURL REQUIRED)
 find_package(SpatiaLite REQUIRED)
 find_package(Sqlite3 REQUIRED)
+find_package(Threads REQUIRED)
 include_directories(${GDAL_INCLUDE_DIR})
 
 if (NOT WIN32)
     set(STDPPFS_LIBRARY stdc++fs)
+    set(THREADS_LIBRARY Threads::Threads)
 endif()
 
-set(LINK_LIBRARIES ${SPATIALITE_LIBRARY} ${SQLITE3_LIBRARY} ${STDPPFS_LIBRARY} exiv2lib ${GDAL_LIBRARY} ${CURL_LIBRARY})
+set(LINK_LIBRARIES ${SPATIALITE_LIBRARY} ${SQLITE3_LIBRARY} ${STDPPFS_LIBRARY} exiv2lib ${GDAL_LIBRARY} ${CURL_LIBRARY} ${THREADS_LIBRARY})
 set(CMD_SRC_LIST ${CMAKE_CURRENT_SOURCE_DIR}/src/cmd/main.cpp)
 
 add_subdirectory("src")

--- a/src/geoproject.cpp
+++ b/src/geoproject.cpp
@@ -53,6 +53,8 @@ void geoProject(const std::vector<std::string> &images, const std::string &outpu
             outFile = output;
         }
 
+        std::string tmpOutFile = fs::path(outFile).replace_extension(".tif.tmp").string();
+
         Point ul = e.polygon_geom.getPoint(0);
         Point ll = e.polygon_geom.getPoint(1);
         Point lr = e.polygon_geom.getPoint(2);
@@ -122,7 +124,6 @@ void geoProject(const std::vector<std::string> &images, const std::string &outpu
 
         std::string vsiFilename = "/vsimem/";
         vsiFilename += p.filename().string() + "-" + std::to_string(rand()) + ".tif";
-
         GDALDatasetH hDstDataset = GDALTranslate(vsiFilename.c_str(),
                                                 hSrcDataset,
                                                 psOptions,
@@ -139,7 +140,7 @@ void geoProject(const std::vector<std::string> &images, const std::string &outpu
         GDALWarpAppOptions* waOptions = GDALWarpAppOptionsNew(wargs, nullptr);
         CSLDestroy(wargs);
 
-        GDALDatasetH hWrpDataset = GDALWarp(outFile.c_str(),
+        GDALDatasetH hWrpDataset = GDALWarp(tmpOutFile.c_str(),
                  nullptr,
                  1,
                  &hDstDataset,
@@ -150,6 +151,8 @@ void geoProject(const std::vector<std::string> &images, const std::string &outpu
         GDALClose(hSrcDataset);
         GDALClose(hDstDataset);
         GDALClose(hWrpDataset);
+
+        fs::rename(tmpOutFile, outFile);
 
         if (callback){
             if (!callback(outFile)) return;

--- a/src/geoproject.cpp
+++ b/src/geoproject.cpp
@@ -120,7 +120,11 @@ void geoProject(const std::vector<std::string> &images, const std::string &outpu
 
         GDALTranslateOptions* psOptions = GDALTranslateOptionsNew(targs, nullptr);
         CSLDestroy(targs);
-        GDALDatasetH hDstDataset = GDALTranslate("/vsimem/translated.tif",
+
+        std::string vsiFilename = "/vsimem/";
+        vsiFilename += p.filename().string() + "-" + std::to_string(rand()) + ".tif";
+
+        GDALDatasetH hDstDataset = GDALTranslate(vsiFilename.c_str(),
                                                 hSrcDataset,
                                                 psOptions,
                                                 nullptr);

--- a/src/geoproject.cpp
+++ b/src/geoproject.cpp
@@ -4,6 +4,7 @@
 
 #include "dbops.h"
 #include "geoproject.h"
+#include "mio.h"
 #include <gdal_priv.h>
 #include <gdal_utils.h>
 
@@ -18,9 +19,7 @@ void geoProject(const std::vector<std::string> &images, const std::string &outpu
             if (fs::is_regular_file(output)){
                 throw FSException(output + " is a file. (Did you switch the input and output parameters?)");
             }
-            if (!fs::create_directories(output)){
-                throw FSException(output + " is not a valid directory (cannot create it).");
-            }
+            io::createDirectories(output);
         }
     }
 

--- a/src/mio.cpp
+++ b/src/mio.cpp
@@ -342,14 +342,19 @@ size_t componentsCount(const fs::path &p){
 fs::path assureFolderExists(const fs::path &d){
     if (!fs::exists(d)){
         // Try to create
-        if (!fs::create_directories(d)){
-            throw FSException(d.string() + " is not a valid directory (cannot create it).");
-        }
+        createDirectories(d);
         return d;
     }else if (fs::is_directory(d)){
         return d;
     }else{
         throw FSException(d.string() + " is not a valid directory (there might be a file with the same name).");
+    }
+}
+
+void createDirectories(const fs::path &d){
+    std::error_code e;
+    if (!fs::create_directories(d, e)) {
+        throw FSException(d.string() + " is not a valid directory (error: " + e.message() + ").");
     }
 }
 

--- a/src/mio.cpp
+++ b/src/mio.cpp
@@ -354,7 +354,10 @@ fs::path assureFolderExists(const fs::path &d){
 void createDirectories(const fs::path &d){
     std::error_code e;
     if (!fs::create_directories(d, e)) {
-        throw FSException(d.string() + " is not a valid directory (error: " + e.message() + ").");
+        // For some reason sometimes this is zero (success)?
+        if (e.value() != 0){
+            throw FSException(d.string() + " is not a valid directory (error: " + e.message() + ").");
+        }
     }
 }
 

--- a/src/mio.cpp
+++ b/src/mio.cpp
@@ -353,5 +353,37 @@ fs::path assureFolderExists(const fs::path &d){
     }
 }
 
+FileLock::FileLock(const fs::path &p){
+    semName = Hash::strCRC64(p.string());
+
+    if ((sem = sem_open(semName.c_str(), O_CREAT, S_IRUSR | S_IWUSR, 1)) == SEM_FAILED){
+        throw ddb::AppException("Cannot acquire semaphore " + semName);
+    }
+
+    // Block
+    LOGD << "Acquiring lock " << semName;
+    std::cout << "ACQUIRED LOCK!" << std::endl;
+    if (sem_wait(sem) != 0){
+        LOGD << "Cannot wait semaphore " + semName;
+    }
+    std::cout << "EXECUTING..." << std::endl;
+}
+
+FileLock::~FileLock(){
+    if (sem_post(sem) != 0){
+        LOGD << "Cannot post semaphore " + semName;
+    }
+    LOGD << "Freeing lock " + semName;
+
+    if (sem_close(sem) != 0){
+        LOGD << "Cannot close semaphore " + semName;
+    }
+
+    if (sem_unlink(semName.c_str()) != 0){
+        LOGD << "Cannot unlink semaphore " + semName;
+    }
+
+}
+
 }
 }

--- a/src/mio.h
+++ b/src/mio.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <fcntl.h>
 #include "fs.h"
 #include "ddb_export.h"
 #include "hash.h"
@@ -18,8 +19,10 @@
 #endif
 
 #ifdef WIN32
+#include <io.h> // _get_osfhandle
+#define	LOCK_EX	2
+#define LOCK_NB 4
 #else
-#include <fcntl.h>
 #include <sys/file.h>
 #endif
 
@@ -71,6 +74,11 @@ public:
     DDB_DLL FileLock(const fs::path &p);
     DDB_DLL ~FileLock();
 };
+
+#ifdef WIN32
+// emulate flock
+int flock (int fd, int operation);
+#endif
 
 DDB_DLL fs::path getExeFolderPath();
 DDB_DLL fs::path getDataPath(const fs::path &p);

--- a/src/mio.h
+++ b/src/mio.h
@@ -11,9 +11,15 @@
 #include <limits>
 #include "fs.h"
 #include "ddb_export.h"
+#include "hash.h"
 
 #ifdef WIN32
 #define stat _stat
+#endif
+
+#ifdef WIN32
+#else
+#include <semaphore.h>
 #endif
 
 namespace fs = std::filesystem;
@@ -55,6 +61,14 @@ public:
 
     DDB_DLL std::string string() const;
     DDB_DLL fs::path get() const{ return p; }
+};
+
+class FileLock{
+    sem_t *sem = nullptr;
+    std::string semName;
+public:
+    FileLock(const fs::path &p);
+    ~FileLock();
 };
 
 DDB_DLL fs::path getExeFolderPath();

--- a/src/mio.h
+++ b/src/mio.h
@@ -19,7 +19,8 @@
 
 #ifdef WIN32
 #else
-#include <semaphore.h>
+#include <fcntl.h>
+#include <sys/file.h>
 #endif
 
 namespace fs = std::filesystem;
@@ -64,8 +65,8 @@ public:
 };
 
 class FileLock{
-    sem_t *sem = nullptr;
-    std::string semName;
+    int fd;
+    std::string lockFile;
 public:
     FileLock(const fs::path &p);
     ~FileLock();

--- a/src/mio.h
+++ b/src/mio.h
@@ -20,10 +20,13 @@
 
 #ifdef WIN32
 #include <io.h> // _get_osfhandle
-#define	LOCK_EX	2
+#define LOCK_EX 2
 #define LOCK_NB 4
 #else
 #include <sys/file.h>
+#define _close close
+#define _unlink unlink
+#define _open open
 #endif
 
 namespace fs = std::filesystem;

--- a/src/mio.h
+++ b/src/mio.h
@@ -68,14 +68,15 @@ class FileLock{
     int fd;
     std::string lockFile;
 public:
-    FileLock(const fs::path &p);
-    ~FileLock();
+    DDB_DLL FileLock(const fs::path &p);
+    DDB_DLL ~FileLock();
 };
 
 DDB_DLL fs::path getExeFolderPath();
 DDB_DLL fs::path getDataPath(const fs::path &p);
 DDB_DLL fs::path getCwd();
 DDB_DLL fs::path assureFolderExists(const fs::path &d);
+DDB_DLL void createDirectories(const fs::path &d);
 
 // Prints to the provided buffer a nice number of bytes (KB, MB, GB, etc)
 DDB_DLL std::string bytesToHuman(std::uintmax_t bytes);

--- a/src/net/request.cpp
+++ b/src/net/request.cpp
@@ -45,7 +45,7 @@ Request::Request(const std::string &url, ReqType reqType)
             LOGD << "CA Bundle: " << caBundlePath.string();
             curl_easy_setopt(curl, CURLOPT_CAINFO, caBundlePath.string().c_str());
         }
-    } catch (AppException &e) {
+    } catch (AppException &) {
         if (curl) curl_easy_cleanup(curl);
         throw;
     }

--- a/src/sensor_data.cpp
+++ b/src/sensor_data.cpp
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+#include <mutex>
 #include "sensor_data.h"
 #include "logger.h"
 #include "exceptions.h"
@@ -8,11 +9,14 @@
 
 namespace ddb{
 
+std::mutex dbInitMutex;
 SqliteDatabase* SensorData::db = nullptr;
 std::map<std::string, double> SensorData::cacheHits;
 std::map<std::string, bool> SensorData::cacheMiss;
 
 void SensorData::checkDbInit(){
+    std::lock_guard<std::mutex> guard(dbInitMutex);
+
     if (db == nullptr){
         db = new SqliteDatabase();
         LOGD << "Initializing sensor database";

--- a/src/tiler.cpp
+++ b/src/tiler.cpp
@@ -141,11 +141,6 @@ Tiler::Tiler(const std::string &geotiffPath, const std::string &outputFolder,
     OSRDestroySpatialReference(inputSrs);
     OSRDestroySpatialReference(outputSrs);
 
-    //    GDALDatasetH test = GDALCreateCopy(pngDrv,
-    //    "/data/drone/brighton2/test.png", inputDataset, FALSE, nullptr,
-    //    nullptr, nullptr); if (test == nullptr) throw GDALException("Cannot
-    //    create output dataset"); GDALClose(test); exit(1);
-
     // TODO: nodata?
     // if (inNodata.size() > 0){
     //        update_no_data_values
@@ -432,8 +427,11 @@ fs::path TilerHelper::toGeoTIFF(const fs::path &tileablePath, int tileSize,
 
         // We need to (attempt) to geoproject the file first
         if (!fs::exists(outputPath) || forceRecreate) {
-            ddb::geoProject({tileablePath.string()}, outputPath.string(),
-                            "100%", true);
+            io::FileLock l(outputPath);
+            if (!fs::exists(outputPath)){
+                ddb::geoProject({tileablePath.string()}, outputPath.string(),
+                                "100%", true);
+            }
         }
 
         return outputPath;

--- a/src/tiler.cpp
+++ b/src/tiler.cpp
@@ -427,7 +427,12 @@ fs::path TilerHelper::toGeoTIFF(const fs::path &tileablePath, int tileSize,
 
         // We need to (attempt) to geoproject the file first
         if (!fs::exists(outputPath) || forceRecreate) {
+            // Multiple processes could be generating the geoprojected
+            // file at the same time, so we place a lock
             io::FileLock l(outputPath);
+
+            // Recheck is needed for other processes that might have generated
+            // the file
             if (!fs::exists(outputPath)){
                 ddb::geoProject({tileablePath.string()}, outputPath.string(),
                                 "100%", true);

--- a/src/tiler.cpp
+++ b/src/tiler.cpp
@@ -57,8 +57,7 @@ std::string Tiler::getTilePath(int z, int x, int y, bool createIfNotExists) {
     // TODO: retina tiles support?
     const fs::path dir = outputFolder / std::to_string(z) / std::to_string(x);
     if (createIfNotExists && !fs::exists(dir)) {
-        if (!fs::create_directories(dir))
-            throw FSException("Cannot create " + dir.string());
+        io::createDirectories(dir);
     }
 
     fs::path p = dir / fs::path(std::to_string(y) + ".png");
@@ -80,10 +79,7 @@ Tiler::Tiler(const std::string &geotiffPath, const std::string &outputFolder,
 
     if (!fs::exists(outputFolder)) {
         // Try to create
-        if (!fs::create_directories(outputFolder)) {
-            throw FSException(outputFolder +
-                              " is not a valid directory (cannot create it).");
-        }
+        io::createDirectories(outputFolder);
     }
 
     pngDrv = GDALGetDriverByName("PNG");

--- a/src/timezone.cpp
+++ b/src/timezone.cpp
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+#include <mutex>
 #include "timezone.h"
 #include "logger.h"
 #include "mio.h"
@@ -10,6 +11,7 @@ using namespace ddb;
 
 bool Timezone::initialized = false;
 ZoneDetect *Timezone::db = nullptr;
+std::mutex timezoneMutex;
 
 [[ noreturn ]] void onError(int errZD, int errNative) {
     throw TimezoneException("Timezone error: " + std::string(ZDGetErrorString(errZD)) + " (" + std::to_string(errNative) + ")");
@@ -17,6 +19,7 @@ ZoneDetect *Timezone::db = nullptr;
 
 void Timezone::init() {
     if (initialized) return;
+    std::lock_guard<std::mutex> guard(timezoneMutex);
 
     ZDSetErrorHandler(onError);
     fs::path dbPath = io::getDataPath("timezone21.bin");

--- a/src/timezone.cpp
+++ b/src/timezone.cpp
@@ -47,7 +47,7 @@ cctz::time_zone Timezone::lookupTimezone(double latitude, double longitude){
             std::string timezoneId = std::string(results[index].data[0]) + std::string(results[index].data[1]);
 
             if (!cctz::load_time_zone(timezoneId, &tz)) {
-                LOGD << "Cannot load timezone, defaulting to UTC: " << timezoneId;
+                LOGD << "Cannot load timezone " << timezoneId << ", defaulting to: " << tz.name();
             } else {
                 found = true;
                 break;

--- a/test/testarea.cpp
+++ b/test/testarea.cpp
@@ -4,6 +4,7 @@
 #include "testarea.h"
 #include "logger.h"
 #include "exceptions.h"
+#include "mio.h"
 
 TestArea::TestArea(const std::string &name, bool recreateIfExists)
     : name(name){
@@ -24,7 +25,7 @@ fs::path TestArea::getFolder(const fs::path &subfolder){
     if (!subfolder.empty()) dir = dir / subfolder;
 
     if (!fs::exists(dir)){
-        if (!fs::create_directories(dir)) throw FSException("Cannot create " + dir.string());
+        io::createDirectories(dir);
         LOGD << "Created test folder " << dir;
     }
     return dir;

--- a/vendor/cctz/src/time_zone_info.cc
+++ b/vendor/cctz/src/time_zone_info.cc
@@ -49,6 +49,10 @@
 #include "time_zone_fixed.h"
 #include "time_zone_posix.h"
 
+#ifdef WIN32
+#include "mio.h"
+#endif
+
 namespace cctz {
 
 namespace {
@@ -634,7 +638,11 @@ std::unique_ptr<ZoneInfoSource> FileZoneInfoSource::Open(
   // Map the time-zone name to a path name.
   std::string path;
   if (name.empty() || name[0] != '/') {
+    #ifdef WIN32
+    const char* tzdir = ddb::io::getDataPath("zoneinfo").string().c_str();
+    #else
     const char* tzdir = "/usr/share/zoneinfo";
+    #endif
     char* tzdir_env = nullptr;
 #if defined(_MSC_VER)
     _dupenv_s(&tzdir_env, nullptr, "TZDIR");


### PR DESCRIPTION
Fixes #177 and #172 by implementing file locking. Multiple processes can request the same geoprojected tiles and will not geo-project the same file concurrently. Processes will wait for the lock to be released before continuing.

