### PR TITLE
Implement fast ddb init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,15 @@ execute_process(COMMAND git rev-parse --short HEAD
 string(REGEX REPLACE "\n$" "" GIT_REV "${GIT_REV}")
 if (NOT "${GIT_REV}" STREQUAL "")
     set(DAPP_VERSION "${APP_VERSION} (git commit ${GIT_REV})")
+    set(DAPP_REVISION "${GIT_REV}")
 else()
     set(DAPP_VERSION "${APP_VERSION}")
+    set(DAPP_REVISION "dev")
 endif()
 
 message("DDB Version: ${DAPP_VERSION}")
 add_compile_options("-DAPP_VERSION=\"${DAPP_VERSION}\"")
+add_compile_options("-DAPP_REVISION=\"${DAPP_REVISION}\"")
 
 # Disable MS warnings
 if (WIN32)

--- a/src/cmd/init.cpp
+++ b/src/cmd/init.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include "fs.h"
 #include "init.h"
-#include "ddb.h"
+#include "dbops.h"
 
 namespace cmd {
 
@@ -15,7 +15,8 @@ void Init::setOptions(cxxopts::Options &opts) {
     .positional_help("[args] [DIRECTORY]")
     .custom_help("init")
     .add_options()
-    ("w,working-dir", "Working directory", cxxopts::value<std::string>()->default_value("."));
+    ("w,working-dir", "Working directory", cxxopts::value<std::string>()->default_value("."))
+    ("from-scratch", "Create the index database from scratch instead of using a prebuilt one (slower)", cxxopts::value<bool>());
     // clang-format on
     opts.parse_positional({"working-dir"});
 }
@@ -26,12 +27,10 @@ std::string Init::description() {
 
 void Init::run(cxxopts::ParseResult &opts) {
     std::string p = opts["working-dir"].as<std::string>();
-    char *outPath;
-    if (DDBInit(p.c_str(), &outPath) == DDBERR_NONE){
-        std::cout << "Initialized empty database in " << outPath << std::endl;
-    }else{
-        std::cerr << DDBGetLastError() << std::endl;
-    }
+    bool fromScratch = opts["from-scratch"].count() > 0;
+
+    std::string outPath = ddb::initIndex(p, fromScratch);
+    std::cout << "Initialized empty database in " << outPath << std::endl;
 }
 
 }

--- a/src/dbops.h
+++ b/src/dbops.h
@@ -30,6 +30,8 @@ DDB_DLL void addToIndex(Database *db, const std::vector<std::string> &paths, Add
 DDB_DLL void removeFromIndex(Database *db, const std::vector<std::string> &paths);
 DDB_DLL void syncIndex(Database *db);
 
+DDB_DLL std::string initIndex(const std::string &directory, bool fromScratch = false);
+
 }
 
 

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -81,46 +81,14 @@ const char* DDBGetVersion() {
 
 DDBErr DDBInit(const char* directory, char** outPath) {
 	DDB_C_BEGIN
+    if (directory == nullptr)
+        throw InvalidArgsException("No directory provided");
 
-	if (directory == nullptr)
-		throw InvalidArgsException("No directory provided");
+    if (outPath == nullptr)
+        throw InvalidArgsException("No output provided");
 
-	if (outPath == nullptr)
-		throw InvalidArgsException("No output provided");
-
-	const fs::path dirPath = directory;
-	if (!exists(dirPath)) throw FSException("Invalid directory: " + dirPath.string() + " (does not exist)");
-
-	auto ddbDirPath = dirPath / ".ddb";
-	if (std::string(directory) == ".") ddbDirPath = ".ddb"; // Nicer to the eye
-	const auto dbasePath = ddbDirPath / "dbase.sqlite";
-
-	LOGD << "Checking if .ddb directory exists...";
-	if (exists(ddbDirPath)) {
-		throw FSException("Cannot initialize database: " + ddbDirPath.string() + " already exists");
-	}
-	
-	if (create_directory(ddbDirPath)) {
-		LOGD << ddbDirPath.string() + " created";
-	}
-	else {
-		throw FSException("Cannot create directory: " + ddbDirPath.string() + ". Check that you have the proper permissions?");
-	}
-
-	LOGD << "Checking if database exists...";
-	if (exists(dbasePath))
-	{
-		throw FSException(ddbDirPath.string() + " already exists");
-	}
-	LOGD << "Creating " << dbasePath.string();
-
-	// Create database
-	auto db = std::make_unique<Database>();
-	db->open(dbasePath.string());
-	db->createTables();
-	db->close();
-
-	utils::copyToPtr(ddbDirPath.string(), outPath);
+    std::string ddbDirPath = ddb::initIndex(directory);
+    utils::copyToPtr(ddbDirPath, outPath);
 	DDB_C_END
 }
 

--- a/src/userprofile.cpp
+++ b/src/userprofile.cpp
@@ -85,6 +85,12 @@ fs::path UserProfile::getTilesDir(){
     return tilesDir;
 }
 
+fs::path UserProfile::getTemplatesDir(){
+    const fs::path tilesDir = getProfileDir() / fs::path("templates");
+    createDir(tilesDir);
+    return tilesDir;
+}
+
 fs::path UserProfile::getAuthFile(){
     return getProfileDir() / "auth.json";
 }

--- a/src/userprofile.h
+++ b/src/userprofile.h
@@ -22,6 +22,7 @@ public:
     DDB_DLL fs::path getThumbsDir();
     DDB_DLL fs::path getThumbsDir(int thumbSize);
     DDB_DLL fs::path getTilesDir();
+    DDB_DLL fs::path getTemplatesDir();
 
     DDB_DLL fs::path getAuthFile();
 

--- a/src/version.h
+++ b/src/version.h
@@ -5,4 +5,8 @@
 #define APP_VERSION "dev"
 #endif
 
+#ifndef APP_REVISION
+#define APP_REVISION "dev"
+#endif
+
 #endif // VERSION_H


### PR DESCRIPTION
Implements #167 

The dbase.sqlite file is cached in `~/.ddb/templates` on the first system-wide `ddb init` and copied subsequently, drastically speeding up the `ddb init` command (especially on Windows, where it's a sloth).