### PR TITLE
Use WAL mode

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -17,6 +17,11 @@ void Database::Initialize() {
 
 void Database::afterOpen(){
   this->setJournalMode("wal");
+  
+  // If table is locked, sleep up to 30 seconds
+  if (sqlite3_busy_timeout(db, 30000) != SQLITE_OK){
+    LOGD << "Cannot set busy timeout";
+  }
 }
 
 Database &Database::createTables() {

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -15,6 +15,10 @@ void Database::Initialize() {
     spatialite_init (0);
 }
 
+void Database::afterOpen(){
+  this->setJournalMode("wal");
+}
+
 Database &Database::createTables() {
     std::string sql = R"<<<(
   SELECT InitSpatialMetaData(1, 'NONE');

--- a/src/database.h
+++ b/src/database.h
@@ -26,6 +26,7 @@ class Database : public SqliteDatabase {
     void clearAttribute(const std::string &name);
   public:
       DDB_DLL static void Initialize();
+      DDB_DLL void afterOpen() override;
       DDB_DLL Database &createTables();
 
       DDB_DLL void setPublic(bool isPublic);

--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -242,7 +242,7 @@ void addToIndex(Database *db, const std::vector<std::string> &paths, AddCallback
     auto insertQ = db->query("INSERT INTO entries (path, hash, type, meta, mtime, size, depth, point_geom, polygon_geom) "
                              "VALUES (?, ?, ?, ?, ?, ?, ?, GeomFromText(?, 4326), GeomFromText(?, 4326))");
     auto updateQ = db->query(UPDATE_QUERY);
-    db->exec("BEGIN TRANSACTION");
+    db->exec("BEGIN EXCLUSIVE TRANSACTION");
 
     for (auto &p : pathList) {
         io::Path relPath = io::Path(p).relativeTo(directory);
@@ -450,7 +450,7 @@ void syncIndex(Database *db) {
     auto deleteQ = db->query("DELETE FROM entries WHERE path = ?");
     auto updateQ = db->query(UPDATE_QUERY);
 
-    db->exec("BEGIN TRANSACTION");
+    db->exec("BEGIN EXCLUSIVE TRANSACTION");
 
     while(q->fetch()) {
         io::Path relPath = fs::path(q->getText(0));

--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -247,7 +247,7 @@ void addToIndex(Database *db, const std::vector<std::string> &paths, AddCallback
     for (auto &p : pathList) {
         io::Path relPath = io::Path(p).relativeTo(directory);
         q->bind(1, relPath.generic());
-          	
+
         bool update = false;
         bool add = false;
         Entry e;

--- a/src/dsmservice.cpp
+++ b/src/dsmservice.cpp
@@ -48,7 +48,7 @@ float DSMService::getAltitude(double latitude, double longitude){
     // TODO: we can probably optimize this
     // to lock based on the bounding box of the point
     {
-        io::FileLock(getCacheDir() / "write.lock");
+        io::FileLock lock(getCacheDir() / ".." / "dsm_service");
 
         // Load existing DSMs in cache until we find a matching one
         if (loadDiskCache(latitude, longitude)){
@@ -132,7 +132,7 @@ bool DSMService::addGeoTIFFToCache(const fs::path &filePath, double latitude, do
 
     std::string wkt = GDALGetProjectionRef(dataset);
     if (wkt.empty()) throw GDALException("Cannot get projection ref for " + filePath.string());
-    char *wktp = const_cast<char *>(wkt.c_str());
+//    char *wktp = const_cast<char *>(wkt.c_str());
     //OGRSpatialReference *srs = new OGRSpatialReference();
     //if (srs->importFromWkt(&wktp) != OGRERR_NONE) throw GDALException("Cannot read spatial reference system for " + filePath.string() + ". Is PROJ installed?");
 

--- a/src/dsmservice.cpp
+++ b/src/dsmservice.cpp
@@ -105,7 +105,7 @@ std::string DSMService::loadFromNetwork(double latitude, double longitude){
                            std::to_string(std::chrono::system_clock::now().time_since_epoch().count()) + ".tif";
     std::string filePath = (getCacheDir() / filename).string();
 
-    std::cout << "Downloading DSM from " << url << " ..." << std::endl;
+    LOGD << "Downloading DSM from " << url << " ...";
     net::Request r = net::GET(url);
 	r.verifySSL(false); // Risk is tolerable, we're just fetching altitude
     r.downloadToFile(filePath);

--- a/src/sqlite_database.cpp
+++ b/src/sqlite_database.cpp
@@ -28,8 +28,13 @@ SqliteDatabase &SqliteDatabase::open(const std::string &file) {
 //    }
 
     this->openFile = file;
+    this->afterOpen();
 
     return *this;
+}
+
+void SqliteDatabase::afterOpen(){
+    // Nothing
 }
 
 SqliteDatabase &SqliteDatabase::close() {
@@ -41,6 +46,9 @@ SqliteDatabase &SqliteDatabase::close() {
 
     return *this;
 }
+
+//    // Activate WAL2 mode
+ 
 
 SqliteDatabase &SqliteDatabase::exec(const std::string &sql) {
     if (db == nullptr) throw DBException("Can't execute SQL: " + sql + ", db is not open");
@@ -74,6 +82,10 @@ std::string SqliteDatabase::getOpenFile(){
 // most recently completed INSERT, UPDATE or DELETE statement
 int SqliteDatabase::changes(){
     return sqlite3_changes(db);
+}
+
+void SqliteDatabase::setJournalMode(const std::string &mode){
+   this->exec("PRAGMA journal_mode=" + mode + ";");
 }
 
 std::unique_ptr<Statement> SqliteDatabase::query(const std::string &query) const{

--- a/src/sqlite_database.cpp
+++ b/src/sqlite_database.cpp
@@ -47,9 +47,6 @@ SqliteDatabase &SqliteDatabase::close() {
     return *this;
 }
 
-//    // Activate WAL2 mode
- 
-
 SqliteDatabase &SqliteDatabase::exec(const std::string &sql) {
     if (db == nullptr) throw DBException("Can't execute SQL: " + sql + ", db is not open");
 

--- a/src/sqlite_database.h
+++ b/src/sqlite_database.h
@@ -20,6 +20,7 @@
 namespace ddb{
 
 class SqliteDatabase {
+  protected:
     sqlite3 *db;
     std::string openFile;
   public:

--- a/src/sqlite_database.h
+++ b/src/sqlite_database.h
@@ -25,11 +25,13 @@ class SqliteDatabase {
   public:
     DDB_DLL SqliteDatabase();
     DDB_DLL SqliteDatabase &open(const std::string &file);
+    DDB_DLL virtual void afterOpen();
     DDB_DLL SqliteDatabase &close();
     DDB_DLL SqliteDatabase &exec(const std::string &sql);
     DDB_DLL bool tableExists(const std::string &table);
     DDB_DLL std::string getOpenFile();
     DDB_DLL int changes();
+    DDB_DLL void setJournalMode(const std::string &mode);
 
     DDB_DLL std::unique_ptr<Statement> query(const std::string &query) const;
 


### PR DESCRIPTION
Closes #186 

It's quite possible that other concurrency issues exists in places with concurrent write access (attributes, deletion, etc.) and those statement should be wrapped in transactions. This PR specifically deals with the more frequent case of parallel uploads for which a test case is easily reproduced.