### PR TITLE
Fix force parameter and set last update when changing attributes

### DIFF
--- a/src/cmd/chattr.cpp
+++ b/src/cmd/chattr.cpp
@@ -67,9 +67,23 @@ void Chattr::run(cxxopts::ParseResult& opts) {
             LOGD << "Setting attributes";
 
             if (attribute == "+public" || attribute == "+p") {
-                db->setPublic(true);
+
+                if (!db->isPublic()) {
+
+                    db->setPublic(true);
+
+                    // Update last edit
+                    db->setLastUpdate();
+                }
             } else if (attribute == "-public" || attribute == "-p") {
-                db->setPublic(false);
+
+                if (db->isPublic()) {
+                    
+                    db->setPublic(false);
+
+                    // Update last edit
+                    db->setLastUpdate();
+                }
             } else {
                 throw ddb::InvalidArgsException("Attribute not valid");
             }

--- a/src/cmd/chattr.cpp
+++ b/src/cmd/chattr.cpp
@@ -68,22 +68,12 @@ void Chattr::run(cxxopts::ParseResult& opts) {
 
             if (attribute == "+public" || attribute == "+p") {
 
-                if (!db->isPublic()) {
+                db->setPublic(true);
 
-                    db->setPublic(true);
-
-                    // Update last edit
-                    db->setLastUpdate();
-                }
             } else if (attribute == "-public" || attribute == "-p") {
 
-                if (db->isPublic()) {
-                    
-                    db->setPublic(false);
+                db->setPublic(false);
 
-                    // Update last edit
-                    db->setLastUpdate();
-                }
             } else {
                 throw ddb::InvalidArgsException("Attribute not valid");
             }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -94,7 +94,12 @@ DDB_DLL void Database::ensureSchemaConsistency() {
 }
 
 void Database::setPublic(bool isPublic) {
+
+    if (this->hasAttribute("public") && 
+        this->getBoolAttribute("public") == isPublic) return;
+
     this->setBoolAttribute("public", isPublic);
+    this->setLastUpdate();
 }
 
 bool Database::isPublic() const {

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -610,16 +610,24 @@ DDB_DLL void Registry::pull(const std::string &path, const bool force,
     LOGD  << "Local mtime " << lastUpdate << ", remote mtime " << dsInfo.mtime;
 
     // 4) Check if we have more recent changes than server, so the pull is pointless or potentially dangerous)
-    if (lastUpdate == dsInfo.mtime){
-        // Nothing to do, datasets should be in sync
-        out << "Already up to date." << std::endl;
-        return;
-    }else if (lastUpdate > dsInfo.mtime && !force)
-        throw AppException(
-            "[Warning] Your dataset has local changes, but you haven't "
-            "pushed these changes to the remote registry. If you pull now, "
-            "your local changes might be overwritten. Use --force "
-            "to continue.");
+
+    if (force) {
+        out << "Forcing pull" << std::endl;
+    } else {
+        if (lastUpdate == dsInfo.mtime) {
+            
+            // Nothing to do, datasets should be in sync
+            out << "Already up to date." << std::endl;
+            return;
+
+        } else if (lastUpdate > dsInfo.mtime) {
+            throw AppException(
+                "[Warning] Your dataset has local changes, but you haven't "
+                "pushed these changes to the remote registry. If you pull now, "
+                "your local changes might be overwritten. Use --force "
+                "to continue.");
+        }
+    }    
 
     const auto tempDdbFolder = UserProfile::get()->getProfilePath("pull_cache", true) /
                                (tagInfo.organization + "-" + tagInfo.dataset);
@@ -771,16 +779,23 @@ DDB_DLL void Registry::push(const std::string &path, const bool force,
 
     // 4) Alert if dataset_mtime > last_sync (it means we have less recent changes
     //    than server, so the push is pointless or potentially dangerous)
-    if (lastUpdate == dsInfo.mtime){
-        // Nothing to do, datasets should be in sync
-        out << "Already up to date." << std::endl;
-        return;
-    }else if (dsInfo.mtime > lastUpdate && !force)
-        throw AppException(
-            "[Warning] The remote dataset has newer changes, but you haven't "
-            "pulled those changes from the remote registry. If you push now, "
-            "the remote dataset might be overwritten. Use --force "
-            "to continue.");
+    
+    if (force) {
+        out << "Forcing push." << std::endl;
+    } else {
+
+        if (lastUpdate == dsInfo.mtime){
+            // Nothing to do, datasets should be in sync
+            out << "Already up to date." << std::endl;
+            return;
+        } else if (dsInfo.mtime > lastUpdate) {
+            throw AppException(
+                "[Warning] The remote dataset has newer changes, but you haven't "
+                "pulled those changes from the remote registry. If you push now, "
+                "the remote dataset might be overwritten. Use --force "
+                "to continue.");
+        }
+    }    
 
     // 5) Initialize server push
     LOGD << "Initializing server push";

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -612,10 +612,10 @@ DDB_DLL void Registry::pull(const std::string &path, const bool force,
     // 4) Check if we have more recent changes than server, so the pull is pointless or potentially dangerous)
 
     if (force) {
-        out << "Forcing pull" << std::endl;
+        out << "Forcing pull." << std::endl;
     } else {
         if (lastUpdate == dsInfo.mtime) {
-            
+
             // Nothing to do, datasets should be in sync
             out << "Already up to date." << std::endl;
             return;


### PR DESCRIPTION
Fixes the behaviour of the `--force` parameter and adds the call to `setLastUpdate` when changing attributes.

Closes #210 