### PR TITLE
Fix setLastTag/getLastTag

### DIFF
--- a/src/syncmanager.cpp
+++ b/src/syncmanager.cpp
@@ -14,6 +14,7 @@
 namespace ddb {
 
 time_t SyncManager::getLastSync(const std::string& registry) {
+    if (!exists(this->ddbFolder)) throw FSException("Cannot get last sync: " + this->ddbFolder.string() + " does not exists");
     const auto path = this->ddbFolder / SYNCFILE;
 
     LOGD << "Path = " << path;
@@ -25,7 +26,6 @@ time_t SyncManager::getLastSync(const std::string& registry) {
 
     if (!exists(path)) {
         LOGD << "Path does not exist, creating empty file";
-        io::assureFolderExists(this->ddbFolder);
         std::ofstream out(path, std::ios_base::out);
         out << "{}";
         out.close();
@@ -45,9 +45,8 @@ time_t SyncManager::getLastSync(const std::string& registry) {
     return t;
 }
 
-void SyncManager::setLastSync(
-    const time_t t, const std::string& registry
-                              ) {
+void SyncManager::setLastSync(const time_t t, const std::string& registry) {
+    if (!exists(this->ddbFolder)) throw FSException("Cannot set last sync: " + this->ddbFolder.string() + " does not exists");
     const auto path = this->ddbFolder / SYNCFILE;
 
     LOGD << "Path = " << path;
@@ -58,7 +57,6 @@ void SyncManager::setLastSync(
         throw InvalidArgsException("Registry cannot be null");
     
     if (!exists(path)) {
-        io::assureFolderExists(this->ddbFolder);
         std::ofstream out(path, std::ios_base::out);
         out << "{}";
         out.close();

--- a/src/syncmanager.cpp
+++ b/src/syncmanager.cpp
@@ -25,7 +25,7 @@ time_t SyncManager::getLastSync(const std::string& registry) {
 
     if (!exists(path)) {
         LOGD << "Path does not exist, creating empty file";
-
+        io::assureFolderExists(this->ddbFolder);
         std::ofstream out(path, std::ios_base::out);
         out << "{}";
         out.close();
@@ -58,6 +58,7 @@ void SyncManager::setLastSync(
         throw InvalidArgsException("Registry cannot be null");
     
     if (!exists(path)) {
+        io::assureFolderExists(this->ddbFolder);
         std::ofstream out(path, std::ios_base::out);
         out << "{}";
         out.close();


### PR DESCRIPTION
During a clone the ".ddb" folder might not exist, and creating the default "tag.json" file fails, leading to ```terminate called after throwing an instance of 'nlohmann::detail::parse_error'
  what():  [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal```
