### PR TITLE
Count entries in ddb info

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -138,17 +138,29 @@ json Database::getAttributes() const {
     j["mtime"] = this->getLastUpdate();
 
     // See if we have a LICENSE.md and README.md in the index
-    const std::string sql =
-        "SELECT path FROM entries WHERE path = 'LICENSE.md' OR path = "
-        "'README.md'";
+    {
+        const std::string sql =
+            "SELECT path FROM entries WHERE path = 'LICENSE.md' OR path = "
+            "'README.md'";
 
-    const auto q = this->query(sql);
-    while (q->fetch()) {
-        const std::string p = q->getText(0);
-        if (p == "README.md") {
-            j["readme"] = p;
-        } else if (p == "LICENSE.md") {
-            j["license"] = p;
+        const auto q = this->query(sql);
+        while (q->fetch()) {
+            const std::string p = q->getText(0);
+            if (p == "README.md") {
+                j["readme"] = p;
+            } else if (p == "LICENSE.md") {
+                j["license"] = p;
+            }
+        }
+    }
+
+    // Count entries
+    {
+        const std::string sql = "SELECT COUNT(1) FROM entries";
+        const auto q = this->query(sql);
+        while (q->fetch()) {
+            const int count = q->getInt(0);
+            j["entries"] = count;
         }
     }
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -159,8 +159,7 @@ json Database::getAttributes() const {
         const std::string sql = "SELECT COUNT(1) FROM entries";
         const auto q = this->query(sql);
         while (q->fetch()) {
-            const int count = q->getInt(0);
-            j["entries"] = count;
+            j["entries"] = q->getInt(0);
         }
     }
 


### PR DESCRIPTION
 - [x] Compiles on Windows and Linux
 - [x] Manual tests on both Windows and Linux to confirm the functionality/command works
 - [x] Manual tests on commands/functionality that might have been affected by these changes.
 - [x] There are no styling changes to unrelated code.

Adds a new "entries" field in the ddb metadata.

```
ddb info
Path: file:///data/test/test/.
Type: DroneDB (7)
Entries: 3
Mtime: 1619797299
Public: false
Modified Time: 1619797298
Size: 0 B
```
