### PR TITLE
Add move support

### DIFF
--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -625,6 +625,9 @@ void moveEntry(Database* db, const std::string& source, const std::string& dest)
     if (dest[dest.length() -1 ] == '/' || dest[dest.length() -1 ] == '\\')
         throw InvalidArgsException("dest cannot end with path separator");
 
+    // Nothing to do
+    if (source == dest) return;
+
     const fs::path directory = rootDirectory(db);
 
     db->exec("BEGIN EXCLUSIVE TRANSACTION");

--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -610,7 +610,7 @@ std::string initIndex(const std::string &directory, bool fromScratch) {
     return ddbDirPath.string();
 }
 
-void ddb::moveEntry(Database* db, const std::string& source, const std::string& dest) {
+void moveEntry(Database* db, const std::string& source, const std::string& dest) {
 
     const fs::path directory = rootDirectory(db);
 

--- a/src/dbops.h
+++ b/src/dbops.h
@@ -30,6 +30,7 @@ DDB_DLL void addToIndex(Database *db, const std::vector<std::string> &paths, Add
 DDB_DLL void removeFromIndex(Database *db, const std::vector<std::string> &paths);
 DDB_DLL void syncIndex(Database *db);
 DDB_DLL void delta(Database* sourceDb, Database* targetDb, std::ostream& out, const std::string& format);
+DDB_DLL void moveEntry(Database* db, const std::string& source, const std::string& dest);
 
 DDB_DLL std::string initIndex(const std::string &directory, bool fromScratch = false);
 

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -403,7 +403,7 @@ DDB_DLL DDBErr DDBMoveEntry(const char *ddbPath, const char *source, const char 
     if (source == nullptr) throw InvalidArgsException("No source path provided");
     if (dest == nullptr) throw InvalidArgsException("No dest path provided");
 
-    const auto ddb = ddb::open(std::string(ddbPath), false);
+    const auto ddb = ddb::open(std::string(ddbPath), true);
 
     ddb::moveEntry(ddb.get(), std::string(source), std::string(dest));
 

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -394,3 +394,19 @@ DDB_DLL DDBErr DDBSetLastSync(const char* ddbPath, const char* registry,
 
     DDB_C_END
 }
+
+DDB_DLL DDBErr DDBMoveEntry(const char *ddbPath, const char *source, const char *dest) {
+
+    DDB_C_BEGIN
+
+    if (ddbPath == nullptr) throw InvalidArgsException("No ddb path provided");
+    if (source == nullptr) throw InvalidArgsException("No source path provided");
+    if (dest == nullptr) throw InvalidArgsException("No dest path provided");
+
+    const auto ddb = ddb::open(std::string(ddbPath), false);
+
+    ddb::moveEntry(ddb.get(), std::string(source), std::string(dest));
+
+    DDB_C_END
+
+}

--- a/src/ddb.h
+++ b/src/ddb.h
@@ -171,6 +171,14 @@ DDB_DLL DDBErr DDBGetLastSync(const char *ddbPath, const char *registry, long lo
  * @return DDBERR_NONE on success, an error otherwise */
 DDB_DLL DDBErr DDBSetLastSync(const char *ddbPath, const char *registry, const long long lastSync);
 
+/** Move entry
+ * @param ddbPath path to the source DroneDB database (parent of ".ddb")
+ * @param source source entry path
+ * @param dest dest entry path
+ * @return DDBERR_NONE on success, an error otherwise */
+DDB_DLL DDBErr DDBMoveEntry(const char *ddbPath, const char *source, const char *dest);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/ddb_test.cpp
+++ b/test/ddb_test.cpp
@@ -761,4 +761,60 @@ TEST(fingerprint, fileHandle) {
 }
 
 
+TEST(moveEntry, happyPath) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset("https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/dbase.sqlite", "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb", fs::copy_options::overwrite_existing);
+
+    auto db = ddb::open(testFolder.string(), false);
+
+    moveEntry(db.get(), "pics.JPG", "pics2/pics/asd.jpg");//"pacs.jpg");
+
+/*
+    std::vector<std::string> toList;
+
+    toList.emplace_back((testFolder / "pics").string());
+    
+    std::ostringstream out; 
+
+    listIndex(db.get(), toList, out, "text", true);
+
+    std::cout << out.str() << std::endl;
+    EXPECT_EQ(out.str(), "pics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\n");
+*/
+}
+
+TEST(moveEntry, happyPath2) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset("https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/dbase.sqlite", "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb", fs::copy_options::overwrite_existing);
+
+    auto db = ddb::open(testFolder.string(), false);
+
+    moveEntry(db.get(), "pics2", "pics3");//"pacs.jpg");
+
+/*
+    std::vector<std::string> toList;
+
+    toList.emplace_back((testFolder / "pics").string());
+    
+    std::ostringstream out; 
+
+    listIndex(db.get(), toList, out, "text", true);
+
+    std::cout << out.str() << std::endl;
+    EXPECT_EQ(out.str(), "pics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\n");
+*/
+}
+
+
+
 }

--- a/test/ddb_test.cpp
+++ b/test/ddb_test.cpp
@@ -760,6 +760,15 @@ TEST(fingerprint, fileHandle) {
 
 }
 
+std::string showList(Database* db, const std::filesystem::path& testFolder) {
+    std::vector<std::string> toList;
+    toList.emplace_back((testFolder / "*").string());
+    std::ostringstream out;
+    listIndex(db, toList, out, "text", true);
+    const auto str = out.str();
+    std::cout << str << std::endl;
+    return str;
+}
 
 TEST(moveEntry, happyPath) {
     TestArea ta(TEST_NAME);
@@ -772,20 +781,14 @@ TEST(moveEntry, happyPath) {
 
     auto db = ddb::open(testFolder.string(), false);
 
+    showList(db.get(), testFolder);
+
     moveEntry(db.get(), "pics.JPG", "pics2/pics/asd.jpg");//"pacs.jpg");
-
-/*
-    std::vector<std::string> toList;
-
-    toList.emplace_back((testFolder / "pics").string());
     
-    std::ostringstream out; 
+    auto str = showList(db.get(), testFolder);    
+    
+    EXPECT_EQ(str, "1JI_0064.JPG\n1JI_0065.JPG\npics\npics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\npics2\npics2/IMG_20160826_181305.jpg\npics2/IMG_20160826_181309.jpg\npics2/pics\npics2/pics/IMG_20160826_181302.jpg\npics2/pics/IMG_20160826_181305.jpg\npics2/pics/IMG_20160826_181309.jpg\npics2/pics/IMG_20160826_181314.jpg\npics2/pics/IMG_20160826_181317.jpg\npics2/pics/asd.jpg\npics2/pics/pics2\npics2/pics/pics2/IMG_20160826_181305.jpg\npics2/pics/pics2/IMG_20160826_181309.jpg\n");
 
-    listIndex(db.get(), toList, out, "text", true);
-
-    std::cout << out.str() << std::endl;
-    EXPECT_EQ(out.str(), "pics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\n");
-*/
 }
 
 TEST(moveEntry, happyPath2) {
@@ -799,20 +802,75 @@ TEST(moveEntry, happyPath2) {
 
     auto db = ddb::open(testFolder.string(), false);
 
+    showList(db.get(), testFolder);
+
     moveEntry(db.get(), "pics2", "pics3");//"pacs.jpg");
 
-/*
-    std::vector<std::string> toList;
-
-    toList.emplace_back((testFolder / "pics").string());
+    auto str = showList(db.get(), testFolder);
     
-    std::ostringstream out; 
+    EXPECT_EQ(str, "1JI_0064.JPG\n1JI_0065.JPG\npics\npics.JPG\npics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\npics3\npics3/IMG_20160826_181305.jpg\npics3/IMG_20160826_181309.jpg\npics3/pics\npics3/pics/IMG_20160826_181302.jpg\npics3/pics/IMG_20160826_181305.jpg\npics3/pics/IMG_20160826_181309.jpg\npics3/pics/IMG_20160826_181314.jpg\npics3/pics/IMG_20160826_181317.jpg\npics3/pics/pics2\npics3/pics/pics2/IMG_20160826_181305.jpg\npics3/pics/pics2/IMG_20160826_181309.jpg\n");
 
-    listIndex(db.get(), toList, out, "text", true);
+}
 
-    std::cout << out.str() << std::endl;
-    EXPECT_EQ(out.str(), "pics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\n");
-*/
+TEST(moveEntry, happyPath3) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset("https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/dbase.sqlite", "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb", fs::copy_options::overwrite_existing);
+
+    auto db = ddb::open(testFolder.string(), false);
+
+    showList(db.get(), testFolder);
+
+    moveEntry(db.get(), "pics2/pics", "pics3");//"pacs.jpg");
+
+    auto str = showList(db.get(), testFolder);
+   
+    EXPECT_EQ(str, "1JI_0064.JPG\n1JI_0065.JPG\npics\npics.JPG\npics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\npics2\npics2/IMG_20160826_181305.jpg\npics2/IMG_20160826_181309.jpg\npics3\npics3/IMG_20160826_181302.jpg\npics3/IMG_20160826_181305.jpg\npics3/IMG_20160826_181309.jpg\npics3/IMG_20160826_181314.jpg\npics3/IMG_20160826_181317.jpg\npics3/pics2\npics3/pics2/IMG_20160826_181305.jpg\npics3/pics2/IMG_20160826_181309.jpg\n");
+
+}
+
+TEST(moveEntry, conflict) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset("https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/dbase.sqlite", "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb", fs::copy_options::overwrite_existing);
+
+    auto db = ddb::open(testFolder.string(), false);
+
+    showList(db.get(), testFolder);
+
+    moveEntry(db.get(), "pics2/pics", "pics2");//"pacs.jpg");
+
+    auto str = showList(db.get(), testFolder);
+   
+    EXPECT_EQ(str, "1JI_0064.JPG\n1JI_0065.JPG\npics\npics.JPG\npics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\npics2\npics2/IMG_20160826_181302.jpg\npics2/IMG_20160826_181305.jpg\npics2/IMG_20160826_181309.jpg\npics2/IMG_20160826_181314.jpg\npics2/IMG_20160826_181317.jpg\npics2/pics2\npics2/pics2/IMG_20160826_181305.jpg\npics2/pics2/IMG_20160826_181309.jpg\n");
+
+}
+
+TEST(moveEntry, badParameters) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset("https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/dbase.sqlite", "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb", fs::copy_options::overwrite_existing);
+
+    auto db = ddb::open(testFolder.string(), false);
+    
+    ASSERT_THROW(moveEntry(db.get(), "pics2/pics/", "pics2"), InvalidArgsException);
+    ASSERT_THROW(moveEntry(db.get(), "pics2/pics", "pics2/"), InvalidArgsException);
+
+    auto str = showList(db.get(), testFolder);
+   
+
 }
 
 


### PR DESCRIPTION
 - [x] Compiles on Windows
 - [x] Compiles on Linux
 - [x] Manual tests on Windows to confirm the functionality/command works
 - [x] Manual tests on Linux to confirm the functionality/command works
 - [x] Manual tests on commands/functionality that might have been affected by these changes.
 - [x] There are no styling changes to unrelated code.

Adds new `moveEntry` function to move an entry to a new path (without touching the filesystem)