### PR TITLE
Refactor of moveEntry and fixes + tests

### DIFF
--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -743,6 +743,8 @@ void moveEntry(Database* db, const std::string& source, const std::string& dest)
 
     db->exec("COMMIT");
 
+    // Update last edit
+    db->setLastUpdate();
 }
 
 }  // namespace ddb

--- a/src/dbops.cpp
+++ b/src/dbops.cpp
@@ -610,11 +610,70 @@ std::string initIndex(const std::string &directory, bool fromScratch) {
     return ddbDirPath.string();
 }
 
-void deleteEntry(Database* db, const std::string path) {
+void deleteEntry(Database* db, const std::string& path) {
 
     auto f = db->query("DELETE FROM entries WHERE path LIKE ?");
     f->bind(1, path);
     f->execute();
+}
+
+bool pathExists(Database* db, const std::string& path) {
+    auto q = db->query("SELECT COUNT(path) FROM entries WHERE path = ?");
+    q->bind(1, path);
+    q->fetch();
+    return q->getInt(0) > 0;
+}
+
+Entry *getEntry(Database* db, const std::string& path, Entry* entry) {
+
+    std::string sql =
+        "SELECT path, hash, type, meta, mtime, size, depth, "
+        "AsGeoJSON(point_geom), AsGeoJSON(polygon_geom) FROM entries WHERE "
+        "path = ?";
+
+    auto q = db->query(sql);
+
+    q->bind(1, path);
+
+    if (!q->fetch()) 
+        return nullptr;  
+
+    *entry = Entry(*q);
+    return entry;
+    
+}
+
+std::vector<std::string> listFolderPaths(Database *db, const std::string& path) {
+
+    std::vector<std::string> res;
+
+    auto q = db->query("SELECT path FROM entries WHERE path LIKE ? OR path = ?");
+
+    q->bind(1, path + "/%");
+    q->bind(2, path);
+    
+    while (q->fetch()) {
+
+        const auto p = q->getText(0);
+
+        res.push_back(p);
+    }
+
+    return res;
+
+}
+
+void replacePath(Database* db, const std::string& source, const std::string& dest) {
+    
+    LOGD << "Replacing '" << source << "' to '" << dest << "'";
+
+    auto depth = io::Path(dest).depth();
+
+    auto update = db->query("UPDATE entries SET path = ?, depth = ? WHERE path = ?");
+    update->bind(1, dest);
+    update->bind(2, depth);
+    update->bind(3, source);
+    update->execute();
 }
 
 void moveEntry(Database* db, const std::string& source, const std::string& dest) {
@@ -634,33 +693,53 @@ void moveEntry(Database* db, const std::string& source, const std::string& dest)
     // Nothing to do
     if (source == dest) return;
 
+    Entry sourceEntry, destEntry;
+    bool sourceExists = getEntry(db, source, &sourceEntry) == nullptr;
+    bool destExists = getEntry(db, dest, &destEntry) != nullptr;
+    
+    // Ensure entry consistency: cannot move file on folder and vice-versa
+    if (sourceExists)
+        throw InvalidArgsException("source path not found");
+    
+    // If dest exists
+    if (destExists) {
+
+        // If source is a folder we cannot move it on anything that exists (only new path)
+        if (sourceEntry.type == EntryType::Directory) {
+            if (destEntry.type != EntryType::Directory)
+                throw InvalidArgsException("Cannot move a folder on a file");
+            else 
+                throw InvalidArgsException("Cannot move a directory on another directory");
+        // If source is a file we cannot move it on a folder
+        } else         
+            if (destEntry.type == EntryType::Directory)
+                throw InvalidArgsException("Cannot move a file on a directory");
+    }
+
     const fs::path directory = rootDirectory(db);
 
     db->exec("BEGIN EXCLUSIVE TRANSACTION");
 
-    auto q = db->query("SELECT path FROM entries WHERE path LIKE ?");
+    // If we are moving a file
+    if (sourceEntry.type != EntryType::Directory) {
+        
+        if (destExists) deleteEntry(db, dest);
+        
+        replacePath(db, source, dest);
+        
+    } else {
 
-    q->bind(1, source + "%");
+        const auto paths = listFolderPaths(db, source);
 
-    while (q->fetch()) {
-        const auto path = q->getText(0);
+        for (const std::string& path : paths) {
 
-        auto newPath = dest + std::string(path).substr(source.length(), std::string::npos);
+            auto newPath = dest + std::string(path).substr(source.length(), std::string::npos);
 
-        LOGD << "Replacing '" << path << "' to '" << newPath << "'";
-
-        auto depth = io::Path(newPath).depth();
-
-        deleteEntry(db, newPath);
-
-        auto update = db->query("UPDATE entries SET path = ?, depth = ? WHERE path = ?");
-        update->bind(1, newPath);
-        update->bind(2, depth);
-        update->bind(3, path);
-        update->execute();
-
-    }
-
+            deleteEntry(db, newPath);
+            replacePath(db, path, newPath);
+            
+        }         
+    }  
 
     db->exec("COMMIT");
 

--- a/test/ddb_test.cpp
+++ b/test/ddb_test.cpp
@@ -846,11 +846,27 @@ TEST(moveEntry, conflict) {
 
     showList(db.get(), testFolder);
 
-    moveEntry(db.get(), "pics2/pics", "pics2");//"pacs.jpg");
+    ASSERT_THROW(moveEntry(db.get(), "pics2/pics", "pics2"), InvalidArgsException);
+    
+}
 
-    auto str = showList(db.get(), testFolder);
-   
-    EXPECT_EQ(str, "1JI_0064.JPG\n1JI_0065.JPG\npics\npics.JPG\npics/IMG_20160826_181302.jpg\npics/IMG_20160826_181305.jpg\npics/IMG_20160826_181309.jpg\npics/IMG_20160826_181314.jpg\npics/IMG_20160826_181317.jpg\npics/pics2\npics/pics2/IMG_20160826_181305.jpg\npics/pics2/IMG_20160826_181309.jpg\npics2\npics2/IMG_20160826_181302.jpg\npics2/IMG_20160826_181305.jpg\npics2/IMG_20160826_181309.jpg\npics2/IMG_20160826_181314.jpg\npics2/IMG_20160826_181317.jpg\npics2/pics2\npics2/pics2/IMG_20160826_181305.jpg\npics2/pics2/IMG_20160826_181309.jpg\n");
+TEST(moveEntry, folderOnFile) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset("https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/dbase.sqlite", "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb", fs::copy_options::overwrite_existing);
+
+    auto db = ddb::open(testFolder.string(), false);
+    
+    ASSERT_THROW(moveEntry(db.get(), "pics2", "pics.JPG"), InvalidArgsException);
+    ASSERT_THROW(moveEntry(db.get(), "pics2/pics", "pics/pics2/IMG_20160826_181305.jpg"), InvalidArgsException);
+    ASSERT_THROW(moveEntry(db.get(), "pics2/pics/pics2/IMG_20160826_181309.jpg", "pics2"), InvalidArgsException);
+    ASSERT_THROW(moveEntry(db.get(), "pics/IMG_20160826_181314.jpg", "pics2/pics"), InvalidArgsException);
+
+    auto str = showList(db.get(), testFolder);   
 
 }
 


### PR DESCRIPTION
 - [x] Compiles on Windows
 - [x] Compiles on Linux
 - [x] Manual tests on Windows to confirm the functionality/command works
 - [x] Manual tests on Linux to confirm the functionality/command works
 - [x] Manual tests on commands/functionality that might have been affected by these changes.
 - [x] There are no styling changes to unrelated code.

Closes #233 and https://github.com/DroneDB/Registry/issues/162