### PR TITLE
Drop PLY support, check file type before EPT building

### DIFF
--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -437,7 +437,7 @@ EntryType fingerprint(const fs::path &path){
     if (markdown)
         return EntryType::Markdown;
 
-    bool pointCloud = p.checkExtension({"laz", "las", "ply"}); // TODO: more?
+    bool pointCloud = p.checkExtension({"laz", "las"}); // TODO: more?
 
     if (pointCloud)
         return EntryType::PointCloud;

--- a/src/pointcloud.cpp
+++ b/src/pointcloud.cpp
@@ -10,6 +10,7 @@
 #include <untwine/bu/BuPyramid.hpp>
 
 #include "pointcloud.h"
+#include "entry.h"
 #include "exceptions.h"
 #include "mio.h"
 #include "geo.h"
@@ -127,6 +128,10 @@ void buildEpt(const std::vector<std::string> &filenames, const std::string &outd
     untwine::Options options;
     for (const std::string &f : filenames){
         if (!fs::exists(f)) throw FSException(f + " does not exist");
+
+        const EntryType type = fingerprint(f);
+        if (type != EntryType::PointCloud) throw InvalidArgsException(f + " is not a supported point cloud file");
+
         options.inputFiles.push_back(f);
     }
     options.tempDir = tmpDir.string();


### PR DESCRIPTION
 - [x] Compiles on Windows
 - [x] Compiles on Linux
 - [x] Manual tests on Windows to confirm the functionality/command works
 - [x] Manual tests on Linux to confirm the functionality/command works
 - [x] Manual tests on commands/functionality that might have been affected by these changes.
 - [x] There are no styling changes to unrelated code.

Closes #244

PLY files are a bit complicated to handle (no SRS, ambiguous file type, could be mesh or point cloud). We'll just support LAS/LAZ for now.
