### PR TITLE
Create EPT builds in ept subfolder

### DIFF
--- a/src/build.cpp
+++ b/src/build.cpp
@@ -19,14 +19,21 @@ void build_internal(Database* db, const Entry& e,
                                
     LOGD << "Building entry " << e.path << " type " << e.type;
 
-    const auto o = (fs::path(outputPath) / e.hash).string();
+    const auto baseOutputPath = fs::path(outputPath) / e.hash;
+    std::string o;
+
+    if (e.type == PointCloud) {
+        o = (baseOutputPath / "ept").string();
+    }else{
+        return; // No build needed
+    }
 
     if (fs::exists(o) && !force) {
         return;
     }
 
-    io::assureFolderExists(outputPath);
-    const auto hardlink = o + "_link" + fs::path(e.path).extension().string();
+    io::assureFolderExists(o);
+    const auto hardlink = baseOutputPath.string() + "_link" + fs::path(e.path).extension().string();
     io::assureIsRemoved(hardlink);
 
     auto relativePath =


### PR DESCRIPTION
 - [x] Compiles on Windows
 - [x] Compiles on Linux
 - [x] Manual tests on Windows to confirm the functionality/command works
 - [x] Manual tests on Linux to confirm the functionality/command works
 - [x] Manual tests on commands/functionality that might have been affected by these changes.
 - [x] There are no styling changes to unrelated code.

Future-proofs build directories to have multiple build outputs per file-type.

In the future we might need to build multiple types of outputs for a single entry. So we now store EPT results in `.ddb/build/<hash>/ept/`.
