### PR TITLE
Added pdal exception handling

### DIFF
--- a/src/pointcloud.cpp
+++ b/src/pointcloud.cpp
@@ -29,8 +29,6 @@ namespace ddb{
 
 bool getPointCloudInfo(const std::string &filename, PointCloudInfo &info, int polyBoundsSrs){
     
-    LOGD << "In getPointCloudInfo(" << filename << ")";
-
     try {
 
         pdal::StageFactory factory;
@@ -82,10 +80,9 @@ bool getPointCloudInfo(const std::string &filename, PointCloudInfo &info, int po
 
                 std::string proj = qi.m_srs.getProj4();
                 if (OSRImportFromProj4(hSrs, proj.c_str()) != OGRERR_NONE){
-                    LOGD << "Cannot import spatial reference system " + proj + ". Is PROJ available?";
-
                     throw GDALException("Cannot import spatial reference system " + proj + ". Is PROJ available?");
                 }
+
                 OSRImportFromEPSG(hTgt, polyBoundsSrs);
                 OGRCoordinateTransformationH hTransform = OCTNewCoordinateTransformation(hSrs, hTgt);
 
@@ -100,7 +97,6 @@ bool getPointCloudInfo(const std::string &filename, PointCloudInfo &info, int po
                 bool maxSuccess = OCTTransform(hTransform, 1, &geoMaxX, &geoMaxY, &geoMaxZ);
 
                 if (!minSuccess || !maxSuccess){
-                    LOGD << "Cannot transform coordinates";
                     throw GDALException("Cannot transform coordinates " + bbox.toWKT() + " to " + proj);
                 }
 
@@ -128,11 +124,9 @@ bool getPointCloudInfo(const std::string &filename, PointCloudInfo &info, int po
             }
         }
 
-    } catch(GDALException& e) {
-        throw;
-    } catch(std::runtime_error& e) {
-        LOGD << "Exception: " << e.what();
-        return false;
+    } catch(pdal::pdal_error& e) {
+        LOGD << "PDAL Error: " << e.what();
+        throw PDALException(e.what());        
     }
 
     return true;


### PR DESCRIPTION
 - [x] Compiles on Windows
 - [x] Compiles on Linux
 - [x] Manual tests on Windows to confirm the functionality/command works
 - [x] Manual tests on Linux to confirm the functionality/command works
 - [x] Manual tests on commands/functionality that might have been affected by these changes.
 - [x] There are no styling changes to unrelated code.

Added try/catch to `getPointCloudInfo` because I'm experiencing an issue on https://github.com/DroneDB/DDB.Bindings/pull/12 with this message: `readers.las: File signature is not 'LASF', is this an LAS/LAZ file?`
The test file is https://github.com/DroneDB/test_data/blob/master/brighton/point_cloud.laz

If I call ddb add or ddb build it works but something is preventing it from working through the .net bindings.
Can @pierotofy point me in the right direction? Maybe some auxiliary library / path is missing or not set correctly?

This error is the same on windows and on Ubuntu 20.04
