### PR TITLE
Fix share callback cancel

### DIFF
--- a/src/shareclient.cpp
+++ b/src/shareclient.cpp
@@ -91,7 +91,8 @@ void ShareClient::Upload(const std::string& path, const fs::path& filePath,
 
             break;  // Done
         } catch (const NetException& e) {
-            if (++retryNum >= MAX_RETRIES) throw e;
+            if (std::string(e.what()).find("Callback aborted") != std::string::npos) throw;
+            if (++retryNum >= MAX_RETRIES) throw;
 
             LOGD << e.what() << ", retrying upload of " << filename
                  << " (attempt " << retryNum << ")";


### PR DESCRIPTION
 - [x] Compiles on Windows
 - [x] Compiles on Linux
 - [x] Manual tests on Windows to confirm the functionality/command works
 - [x] Manual tests on Linux to confirm the functionality/command works
 - [x] Manual tests on commands/functionality that might have been affected by these changes.
 - [x] There are no styling changes to unrelated code.

Fixes the cancel callback logic; currently a cancel is caught by the try/catch block and handled as a retry (which is wrong), blocking the calling UI process.