### PR TITLE
Add support for CWD in meta API

### DIFF
--- a/src/cmd/meta.cpp
+++ b/src/cmd/meta.cpp
@@ -92,15 +92,15 @@ void Meta::run(cxxopts::ParseResult &opts) {
             std::cerr << "Note: saving metadata as \"" << key << "\" (plural)" << std::endl;
         }
         output(std::cout, metaManager.add(key, data, path), format);
-    }else if (command == "set" || command == "s"){
+    } else if (command == "set" || command == "s"){
         output(std::cout, metaManager.set(key, data, path) , format);
-    }else if (command == "rm" || command == "r" || command == "remove"){
+    } else if (command == "rm" || command == "r" || command == "remove"){
         output(std::cout, metaManager.remove(key), format);
-    }else if (command == "get" || command == "g"){
+    } else if (command == "get" || command == "g"){
         output(std::cout, metaManager.get(key, path), format);
-    }else if (command == "unset" || command == "u"){
+    } else if (command == "unset" || command == "u"){
         output(std::cout, metaManager.unset(key, path), format);
-    }else if (command == "list" || command == "ls" || command == "l"){
+    } else if (command == "list" || command == "ls" || command == "l"){
         output(std::cout, metaManager.list(path), format);
     }
 }

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -471,8 +471,10 @@ DDBErr DDBMetaAdd(const char *ddbPath, const char *path, const char *key, const 
     if (key == nullptr) throw InvalidArgsException("No key provided");
     if (data == nullptr) throw InvalidArgsException("No data provided");
 
-    const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->add(std::string(key), std::string(data), std::string(path), std::string(ddbPath));
+    const auto ddbPathStr = std::string(ddbPath);
+
+    const auto ddb = ddb::open(ddbPathStr, true);
+    auto json = ddb->getMetaManager()->add(std::string(key), std::string(data), std::string(path), ddbPathStr);
 
     utils::copyToPtr(json.dump(), output);
 
@@ -487,8 +489,10 @@ DDBErr DDBMetaSet(const char *ddbPath, const char *path, const char *key, const 
     if (key == nullptr) throw InvalidArgsException("No key provided");
     if (data == nullptr) throw InvalidArgsException("No data provided");
 
-    const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->set(std::string(key), std::string(data), std::string(path), std::string(ddbPath));
+    const auto ddbPathStr = std::string(ddbPath);
+
+    const auto ddb = ddb::open(ddbPathStr, true);
+    auto json = ddb->getMetaManager()->set(std::string(key), std::string(data), std::string(path), ddbPathStr);
 
     utils::copyToPtr(json.dump(), output);
 
@@ -516,8 +520,10 @@ DDB_DLL DDBErr DDBMetaGet(const char *ddbPath, const char *path, const char *key
     if (path == nullptr) throw InvalidArgsException("No path provided");
     if (key == nullptr) throw InvalidArgsException("No key provided");
 
-    const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->get(std::string(key), std::string(path), std::string(ddbPath));
+    const auto ddbPathStr = std::string(ddbPath);
+
+    const auto ddb = ddb::open(ddbPathStr, true);
+    auto json = ddb->getMetaManager()->get(std::string(key), std::string(path), ddbPathStr);
 
     utils::copyToPtr(json.dump(), output);
 
@@ -545,8 +551,10 @@ DDB_DLL DDBErr DDBMetaList(const char *ddbPath, const char *path, char **output)
     if (ddbPath == nullptr) throw InvalidArgsException("No ddb path provided");
     if (path == nullptr) throw InvalidArgsException("No path provided");
 
-    const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->list(std::string(path), std::string(ddbPath));
+    const auto ddbPathStr = std::string(ddbPath);
+
+    const auto ddb = ddb::open(ddbPathStr, true);
+    auto json = ddb->getMetaManager()->list(std::string(path), ddbPathStr);
 
     utils::copyToPtr(json.dump(), output);
 

--- a/src/ddb.cpp
+++ b/src/ddb.cpp
@@ -472,7 +472,7 @@ DDBErr DDBMetaAdd(const char *ddbPath, const char *path, const char *key, const 
     if (data == nullptr) throw InvalidArgsException("No data provided");
 
     const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->add(std::string(key), std::string(data), std::string(path));
+    auto json = ddb->getMetaManager()->add(std::string(key), std::string(data), std::string(path), std::string(ddbPath));
 
     utils::copyToPtr(json.dump(), output);
 
@@ -488,7 +488,7 @@ DDBErr DDBMetaSet(const char *ddbPath, const char *path, const char *key, const 
     if (data == nullptr) throw InvalidArgsException("No data provided");
 
     const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->set(std::string(key), std::string(data), std::string(path));
+    auto json = ddb->getMetaManager()->set(std::string(key), std::string(data), std::string(path), std::string(ddbPath));
 
     utils::copyToPtr(json.dump(), output);
 
@@ -517,7 +517,7 @@ DDB_DLL DDBErr DDBMetaGet(const char *ddbPath, const char *path, const char *key
     if (key == nullptr) throw InvalidArgsException("No key provided");
 
     const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->get(std::string(key), std::string(path));
+    auto json = ddb->getMetaManager()->get(std::string(key), std::string(path), std::string(ddbPath));
 
     utils::copyToPtr(json.dump(), output);
 
@@ -532,7 +532,7 @@ DDB_DLL DDBErr DDBMetaUnset(const char *ddbPath, const char *path, const char *k
     if (key == nullptr) throw InvalidArgsException("No key provided");
 
     const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->unset(std::string(key), std::string(path));
+    auto json = ddb->getMetaManager()->unset(std::string(key), std::string(path), std::string(ddbPath));
 
     utils::copyToPtr(json.dump(), output);
 
@@ -546,7 +546,7 @@ DDB_DLL DDBErr DDBMetaList(const char *ddbPath, const char *path, char **output)
     if (path == nullptr) throw InvalidArgsException("No path provided");
 
     const auto ddb = ddb::open(std::string(ddbPath), true);
-    auto json = ddb->getMetaManager()->list(std::string(path));
+    auto json = ddb->getMetaManager()->list(std::string(path), std::string(ddbPath));
 
     utils::copyToPtr(json.dump(), output);
 

--- a/src/metamanager.h
+++ b/src/metamanager.h
@@ -29,7 +29,7 @@ public:
 
     DDB_DLL json add(const std::string& key, const std::string &data, const std::string &path = "", const std::string &cwd = "");
     DDB_DLL json set(const std::string& key, const std::string &data, const std::string &path = "", const std::string &cwd = "");
-    DDB_DLL json remove(const std::string& key);
+    DDB_DLL json remove(const std::string& id);
     DDB_DLL json get(const std::string& key, const std::string &path = "", const std::string &cwd = "");
     DDB_DLL json unset(const std::string& key, const std::string &path = "", const std::string &cwd = "");
     DDB_DLL json list(const std::string &path = "", const std::string &cwd = "") const;

--- a/src/metamanager.h
+++ b/src/metamanager.h
@@ -15,7 +15,7 @@ class Database;
 class MetaManager {
     Database* db;
 
-    std::string entryPath(const std::string &path) const;
+    std::string entryPath(const std::string &path, const std::string &cwd = "") const;
 
     std::string getKey(const std::string &key, bool isList) const;
     json getMetaJson(Statement *q) const;
@@ -27,12 +27,12 @@ public:
     MetaManager(ddb::Database* db) : db(db) {}
 
 
-    DDB_DLL json add(const std::string& key, const std::string &data, const std::string &path = "");
-    DDB_DLL json set(const std::string& key, const std::string &data, const std::string &path = "");
+    DDB_DLL json add(const std::string& key, const std::string &data, const std::string &path = "", const std::string &cwd = "");
+    DDB_DLL json set(const std::string& key, const std::string &data, const std::string &path = "", const std::string &cwd = "");
     DDB_DLL json remove(const std::string& key);
-    DDB_DLL json get(const std::string& key, const std::string &path = "");
-    DDB_DLL json unset(const std::string& key, const std::string &path = "");
-    DDB_DLL json list(const std::string &path = "") const;
+    DDB_DLL json get(const std::string& key, const std::string &path = "", const std::string &cwd = "");
+    DDB_DLL json unset(const std::string& key, const std::string &path = "", const std::string &cwd = "");
+    DDB_DLL json list(const std::string &path = "", const std::string &cwd = "") const;
 };
 
 }

--- a/test/meta_test.cpp
+++ b/test/meta_test.cpp
@@ -1,0 +1,192 @@
+
+#include "gtest/gtest.h"
+#include "dbops.h"
+#include "exceptions.h"
+#include "test.h"
+#include "testarea.h"
+
+namespace {
+
+using namespace ddb;
+
+TEST(meta, happyPath) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset(
+        "https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/"
+        "dbase.sqlite",
+        "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb",
+             fs::copy_options::overwrite_existing);
+
+    const auto tf = testFolder.string();
+
+    const auto db = ddb::open(tf, false);
+
+    MetaManager manager(db.get());
+
+    // Should be nothing
+    auto lst = manager.list();
+    EXPECT_EQ(lst.size(), 0);
+
+    // Add 3 annotations
+    manager.add("annotations", "this is a string", "", tf);
+    const auto itm =
+        manager.add("annotations", R"({"test":"this is an object"})", "", tf);
+    manager.add("annotations", R"({"test":1234, "dummy": [123,43,45,{}]})", "",
+                tf);
+
+    // Should be 3
+    lst = manager.list();
+    LOGD << lst.dump();
+    EXPECT_EQ(lst.size(), 1);
+    EXPECT_EQ(lst[0]["count"], 3);
+
+    // Check data
+    const auto gt = manager.get("annotations", "", tf);
+    EXPECT_EQ(gt.size(), 3);
+    EXPECT_EQ(gt[0]["data"], "this is a string");
+    EXPECT_EQ(gt[1]["data"], json::parse(R"({"test":"this is an object"})"));
+    EXPECT_EQ(gt[2]["data"],
+              json::parse(R"({"test":1234, "dummy": [123,43,45,{}]})"));
+
+    // Wrong key should throw exception
+    EXPECT_THROW(manager.get("annotation", "", tf), InvalidArgsException);
+
+    // Remove one annotation
+    auto rm = manager.remove(itm["id"]);
+    EXPECT_EQ(rm["removed"], 1);
+
+    // Second time should do nothing
+    rm = manager.remove(itm["id"]);
+    EXPECT_EQ(rm["removed"], 0);
+
+    // Set config meta
+    auto cfg = manager.set("config", R"([123,432,"ehy"])", "", tf);
+    LOGD << cfg.dump();
+
+    // Check config data
+    EXPECT_EQ(cfg["data"], json::parse(R"([123,432,"ehy"])"));
+
+    // Check list count
+    lst = manager.list();
+    EXPECT_EQ(lst.size(), 2);
+    EXPECT_EQ(lst[0]["count"], 2);
+    EXPECT_EQ(lst[1]["count"], 1);
+
+    // Unset annotations (2 left)
+    auto us = manager.unset("annotations", "", tf);
+    EXPECT_EQ(us["removed"], 2);
+
+    // Check list count (1)
+    lst = manager.list();
+    EXPECT_EQ(lst.size(), 1);
+    EXPECT_EQ(lst[0]["count"], 1);
+
+    // Remove config
+    rm = manager.remove(cfg["id"]);
+    EXPECT_EQ(rm["removed"], 1);
+
+    // Check list count (0)
+    lst = manager.list();
+    EXPECT_EQ(lst.size(), 0);
+}
+
+TEST(meta, happyPathWithPath) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset(
+        "https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/"
+        "dbase.sqlite",
+        "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb",
+             fs::copy_options::overwrite_existing);
+
+    const auto tf = testFolder.string();
+
+    LOGD << "TestFolder = " << tf;
+
+    const auto db = ddb::open(tf, false);
+
+    MetaManager manager(db.get());
+
+    // Should be nothing
+    auto lst = manager.list("", tf);
+    EXPECT_EQ(lst.size(), 0);
+
+    // Add 3 annotations
+    manager.add("annotations", "this is a string", "1JI_0065.JPG", tf);
+    const auto itm = manager.add("annotations", R"({"test":"this is an object"})", "1JI_0065.JPG", tf);
+    manager.add("annotations", R"({"test":1234, "dummy": [123,43,45,{}]})", "1JI_0064.JPG", tf);
+
+    // Should be 0 without path
+    lst = manager.list("", tf);
+    LOGD << lst.dump();
+    EXPECT_EQ(lst.size(), 2);
+    EXPECT_EQ(lst[0]["count"], 1);
+    EXPECT_EQ(lst[1]["count"], 2);
+
+    // Should be 2 with path "1JI_0065.JPG"
+    lst = manager.list("1JI_0065.JPG", tf);
+    LOGD << lst.dump();
+    EXPECT_EQ(lst.size(), 1);
+    EXPECT_EQ(lst[0]["count"], 2);
+
+    // Should be 1 with path "1JI_0064.JPG"
+    lst = manager.list("1JI_0064.JPG", tf);
+    LOGD << lst.dump();
+    EXPECT_EQ(lst.size(), 1);
+    EXPECT_EQ(lst[0]["count"], 1);
+
+    // Unset annotations with path "1JI_0065.JPG" (2 left)
+    auto us = manager.unset("annotations", "1JI_0065.JPG", tf);
+    EXPECT_EQ(us["removed"], 2);
+
+    // Unset annotations with path "1JI_0064.JPG" (2 left)
+    us = manager.unset("annotations", "1JI_0064.JPG", tf);
+    EXPECT_EQ(us["removed"], 1);
+
+    // Check list count (0)
+    lst = manager.list("", tf);
+    EXPECT_EQ(lst.size(), 0);
+}
+
+TEST(meta, variousErrors) {
+    TestArea ta(TEST_NAME);
+
+    const auto sqlite = ta.downloadTestAsset(
+        "https://github.com/DroneDB/test_data/raw/master/ddb-remove-test/.ddb/"
+        "dbase.sqlite",
+        "dbase.sqlite");
+
+    const auto testFolder = ta.getFolder("test");
+    create_directory(testFolder / ".ddb");
+    fs::copy(sqlite.string(), testFolder / ".ddb",
+             fs::copy_options::overwrite_existing);
+
+    const auto tf = testFolder.string();
+
+    const auto db = ddb::open(tf, false);
+
+    MetaManager manager(db.get());
+
+    // Path does not exist
+    EXPECT_THROW(manager.list("WOUYIFBGHOPWU", tf), InvalidArgsException);
+
+    // Malformed JSON
+    EXPECT_THROW(manager.add("annotations", "{\"ciao\":}", "", tf), JSONException);
+
+    // Expect plural
+    EXPECT_THROW(manager.add("annotation", "1234", "", tf), InvalidArgsException);
+    
+}
+
+
+
+} 

--- a/test/zip_test.cpp
+++ b/test/zip_test.cpp
@@ -26,6 +26,9 @@ TEST(zip, createExtract) {
     // Create
     std::string zipFile = (ta.getFolder(".") / "archive.zip").string();
 
+    // Cleanup if it already exists
+    fs::remove(zipFile);
+
     zip::zipFolder(dir.string(),
                    zipFile,
                    {"subdir/exclude.txt", "exclude/"});


### PR DESCRIPTION
Adds support for CWD in the Meta Manager, allowing API calls to use relative paths to the DroneDB path automatically.
