### PR TITLE
Fix clone for public/unlisted datasets without requiring login

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddb",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Effortless aerial data management and sharing",
   "main": "index.js",
   "directories": {

--- a/src/clone.cpp
+++ b/src/clone.cpp
@@ -18,7 +18,7 @@
 namespace ddb {
 
 void clone(const TagComponents& tag, const std::string& folder) {
-    if (fs::exists(folder)) {
+    if (fs::exists(folder) && !fs::is_empty(folder)) {
         std::cout << "Cannot clone in folder '" + folder +
                          "' because it already exists" << std::endl;
         return;
@@ -34,28 +34,9 @@ void clone(const TagComponents& tag, const std::string& folder) {
     Registry reg(tag.registryUrl);
 
     try {
-        if (ac.empty()) {
-
-            const auto username = utils::getPrompt("Username: ");
-            const auto password = utils::getPass("Password: ");
-
-            if (reg.login(username, password).length() <= 0) 
-                throw AuthException("Cannot authenticate with " + reg.getUrl());
-            
-            UserProfile::get()->getAuthManager()->saveCredentials(
-                tag.registryUrl, AuthCredentials(username, password));
-
-            reg.clone(tag.organization, tag.dataset, folder, std::cout);
-
-        } else {
-
-            if (reg.login(ac.username, ac.password).length() <= 0) 
-                throw AuthException("Cannot authenticate with " + reg.getUrl());
-            
-            reg.clone(tag.organization, tag.dataset, folder, std::cout);
-        }
-
+        reg.clone(tag.organization, tag.dataset, folder, std::cout);
     } catch (const AuthException&) {
+        io::assureIsRemoved(folder);
         const auto username = utils::getPrompt("Username: ");
         const auto password = utils::getPass("Password: ");
 

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -102,8 +102,7 @@ std::string Registry::login(const std::string &username,
 }
 
 void Registry::ensureTokenValidity() {
-    if (this->authToken.empty())
-        throw InvalidArgsException("No auth token is present");
+    if (this->authToken.empty()) return; // No credentials saved
 
     const auto now = std::time(nullptr);
 
@@ -128,7 +127,7 @@ bool Registry::logout() {
 void Registry::clone(const std::string &organization,
                              const std::string &dataset,
                              const std::string &folder, std::ostream &out) {
-    if (fs::exists(folder)){
+    if (fs::exists(folder) && !fs::is_empty(folder)){
         throw FSException(folder + " already exists");
     }
 
@@ -703,6 +702,7 @@ void Registry::push(const std::string &path, std::ostream &out) {
 }
 
 void Registry::handleError(net::Response &res) {
+    if (res.status() == 401) throw AuthException("Unauthorized");
     if (res.hasData()) {
         LOGD << "Request error: " << res.getText();
 


### PR DESCRIPTION
As the title says; public datasets should not require authentication.﻿
