### PR TITLE
Force build bypasses stale lock detection

### DIFF
--- a/src/include/buildlock.h
+++ b/src/include/buildlock.h
@@ -101,8 +101,15 @@ private:
     /**
      * @brief Acquire the build lock with specified wait behavior
      *
-     * @param waitForLock If true, use blocking behavior (CREATE_ALWAYS on Windows).
-     *                    If false, fail immediately if lock exists (CREATE_NEW on Windows)
+     * @param waitForLock Controls lock acquisition strategy:
+     *   - **Windows**: true = CREATE_ALWAYS (overwrites orphaned files, blocks on
+     *     active handles); false = CREATE_NEW (fails immediately if file exists).
+     *   - **Unix/Linux**: Both modes use O_CREAT|O_EXCL (pure exclusivity). Stale
+     *     lock file recovery is **not** handled here — the caller (build.cpp) must
+     *     detect stale locks via PID liveness checks and remove them before retrying.
+     *     This asymmetry exists because Unix unlink() on an open file succeeds
+     *     (removing the directory entry but not the inode), which would break
+     *     mutual exclusion if done inside BuildLock.
      *
      * @throws AppException If the lock cannot be acquired
      */

--- a/src/library/build.cpp
+++ b/src/library/build.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <optional>
 #include <sstream>
 
 #include "3d.h"
@@ -29,6 +30,10 @@
 #endif
 
 namespace ddb {
+
+// Forward declarations for stale lock detection helpers (defined later in this file)
+static long readPidFromLockFile(const std::string& lockFilePath);
+static bool isLockFileStale(const std::string& lockFilePath);
 
 bool isBuildableInternal(const Entry& e, std::string& subfolder) {
     if (e.type == EntryType::PointCloud) {
@@ -134,7 +139,40 @@ void buildInternal(Database* db, const Entry& e, const std::string& outputPath, 
     // Acquire inter-process lock to prevent race conditions between different processes
     // This must come BEFORE the ThreadLock to ensure proper ordering of lock acquisition
     LOGD << "Acquiring inter-process build lock for: " << outputFolder;
-    BuildLock processLock(outputFolder);
+
+    // Helper lambda: try to acquire the build lock, optionally removing stale locks first
+    auto acquireBuildLock = [&](bool removeStale) -> std::optional<BuildLock> {
+        if (removeStale) {
+            std::string lockFile = outputFolder + ".building";
+            if (fs::exists(lockFile)) {
+                if (isLockFileStale(lockFile)) {
+                    LOGD << "Force build: removing stale lock file (dead PID): " << lockFile;
+                    try {
+                        io::assureIsRemoved(lockFile);
+                    } catch (const std::exception& err) {
+                        LOGW << "Failed to remove stale lock file: " << err.what();
+                    }
+                } else {
+                    long activePid = readPidFromLockFile(lockFile);
+                    std::string pidInfo = activePid > 0 ? " (PID: " + std::to_string(activePid) + ")" : "";
+                    LOGD << "Force build: lock held by active process" << pidInfo << ", cannot override: " << lockFile;
+                    throw BuildInProgressException("Build in progress by another process" + pidInfo);
+                }
+            }
+        }
+        return BuildLock(outputFolder);
+    };
+
+    std::optional<BuildLock> processLockOpt;
+    try {
+        processLockOpt = acquireBuildLock(false);
+    } catch (const BuildInProgressException&) {
+        if (!force) throw;
+        // Force mode: attempt to reclaim stale lock and retry
+        LOGD << "Build lock failed, force=true: attempting stale lock removal and retry";
+        processLockOpt = acquireBuildLock(true);
+    }
+    BuildLock& processLock = *processLockOpt;
 
     // Acquire intra-process lock to coordinate between threads of the same process
     ThreadLock threadLock("build-" + (db->rootDirectory() / e.hash).string());

--- a/src/library/buildlock.cpp
+++ b/src/library/buildlock.cpp
@@ -233,7 +233,13 @@ void BuildLock::acquireLock(bool waitForLock) {
     LOGD << "Build lock acquired successfully" << (waitForLock ? "" : " (no wait)") << ": " << lockFilePath;
 
 #else
-    // Unix implementation using open() with O_EXCL for atomic creation
+    // Unix implementation
+    // Note: stale lock file recovery is handled at a higher level (build.cpp)
+    // via PID-based liveness checks. BuildLock remains a pure exclusivity primitive
+    // using O_EXCL — it never removes existing lock files, as unlink() on an open
+    // file succeeds on Unix (removing the directory entry while the inode persists),
+    // which would break mutual exclusion between concurrent processes.
+
     // O_EXCL ensures that open() fails if the file already exists
     fileDescriptor = open(
         lockFilePath.c_str(),

--- a/tests/buildlock_test.cpp
+++ b/tests/buildlock_test.cpp
@@ -5,11 +5,13 @@
 #include "buildlock.h"
 #include "exceptions.h"
 #include "gtest/gtest.h"
+#include "mio.h"
 #include "test.h"
 #include "testarea.h"
 
 #include <thread>
 #include <chrono>
+#include <fstream>
 #include <future>
 #include <vector>
 #include <string>
@@ -387,5 +389,99 @@ TEST_F(BuildLockTest, IsBuildActiveDetection) {
 }
 
 
+
+/**
+ * @brief Test that BuildLock correctly handles a pre-existing lock file on disk.
+ * On Windows, CREATE_ALWAYS naturally reclaims orphaned files (no process handle).
+ * On Linux, O_EXCL is a pure exclusivity primitive — stale recovery is the caller's
+ * responsibility (build.cpp uses PID-based liveness checks).
+ */
+TEST_F(BuildLockTest, WaitMode_OrphanedLockFileOnDisk) {
+    auto outputPath = testArea->getPath("stale_lock_test");
+
+    // Simulate an orphaned lock: create .building file with a dead PID (no process holding it)
+    std::string lockFile = outputPath.string() + ".building";
+    {
+        std::ofstream f(lockFile);
+        f << "PID: 99\nProcess: Simulated stale\n";
+    }
+    ASSERT_TRUE(fs::exists(lockFile));
+
+#ifdef WIN32
+    // Windows CREATE_ALWAYS overwrites the orphaned file → lock acquired
+    {
+        BuildLock lock(outputPath.string());  // wait=true
+        EXPECT_TRUE(lock.isHolding());
+    }
+#else
+    // Linux O_EXCL fails because the file exists — stale recovery is the caller's job
+    EXPECT_THROW({
+        BuildLock lock(outputPath.string());  // wait=true
+    }, BuildInProgressException);
+    // Clean up for next tests
+    io::assureIsRemoved(lockFile);
+#endif
+}
+
+/**
+ * @brief Test that wait=false (non-blocking check) fails against an orphaned lock file
+ * that has no valid process behind it — this is the isBuildActive check path.
+ * The lock file exists on disk but no one holds a file handle on it.
+ */
+TEST_F(BuildLockTest, NoWaitMode_FailsOnOrphanedLockFile) {
+    auto outputPath = testArea->getPath("orphan_lock_test");
+
+    // Create an orphaned lock file with dead PID (no process holds a handle)
+    std::string lockFile = outputPath.string() + ".building";
+    {
+        std::ofstream f(lockFile);
+        f << "PID: 99\n";
+    }
+    ASSERT_TRUE(fs::exists(lockFile));
+
+    // Both platforms: wait=false always uses exclusive-create semantics
+    // (CREATE_NEW on Windows, O_EXCL on Linux), so existing file → fail
+    EXPECT_THROW({
+        BuildLock lock(outputPath.string(), false);
+    }, BuildInProgressException);
+
+    // Clean up
+    io::assureIsRemoved(lockFile);
+}
+
+/**
+ * @brief Test the force-build scenario at the lock level:
+ * 1. A lock file is left on disk (simulating crashed build)
+ * 2. wait=false fails (isBuildActive detects "active")
+ * 3. Caller removes the stale file (simulating build.cpp stale-detection logic)
+ * 4. wait=true succeeds (force build proceeds after caller-side cleanup)
+ */
+TEST_F(BuildLockTest, ForceBuildScenario_StaleLockRecovery) {
+    auto outputPath = testArea->getPath("force_build_scenario");
+
+    // Step 1: Simulate crashed build leaving a lock file with dead PID
+    std::string lockFile = outputPath.string() + ".building";
+    {
+        std::ofstream f(lockFile);
+        f << "PID: 99\nProcess: Crashed build\n";
+    }
+    ASSERT_TRUE(fs::exists(lockFile));
+
+    // Step 2: Non-blocking check should detect "build in progress"
+    EXPECT_THROW({
+        BuildLock checkLock(outputPath.string(), false);
+    }, BuildInProgressException);
+
+    // Step 3: Simulate caller-side stale lock removal (as build.cpp does after
+    // verifying the lock is stale via isLockFileStale/isProcessAlive)
+    io::assureIsRemoved(lockFile);
+    ASSERT_FALSE(fs::exists(lockFile));
+
+    // Step 4: Lock acquisition succeeds after stale file removal
+    {
+        BuildLock forceLock(outputPath.string());  // wait=true
+        EXPECT_TRUE(forceLock.isHolding());
+    }
+}
 
 } // anonymous namespace

--- a/tests/isbuildactive_test.cpp
+++ b/tests/isbuildactive_test.cpp
@@ -229,4 +229,51 @@ TEST_F(IsBuildActiveTest, RealBuildInThread) {
     EXPECT_TRUE(isActive) << "isBuildActive should have detected the running build";
 }
 
+TEST_F(IsBuildActiveTest, StaleLockFileIsCleanedUp) {
+    // Test that isBuildActive detects and cleans up stale lock files
+    // (lock files left by crashed processes with dead PIDs)
+    Entry orthoEntry;
+    fs::path relativePath = fs::relative(orthoPath, dbPath);
+    ASSERT_TRUE(ddb::getEntry(db.get(), relativePath.string(), orthoEntry));
+
+    // Construct the build lock file path (matches what build.cpp uses)
+    std::string buildPath = db->buildDirectory().string();
+    fs::path orthoOutputPath = fs::path(buildPath) / orthoEntry.hash / "cog";
+    fs::create_directories(orthoOutputPath.parent_path());
+    std::string lockFile = orthoOutputPath.string() + ".building";
+
+    // Create a stale lock file with a dead PID (PID 99 should not be running)
+    {
+        std::ofstream f(lockFile);
+        f << "PID: 99\nProcess: Simulated crashed build\n";
+    }
+    ASSERT_TRUE(fs::exists(lockFile));
+
+    // isBuildActive should detect the stale lock, clean it up, and return false
+    EXPECT_FALSE(ddb::isBuildActive(db.get(), relativePath.string()));
+
+    // The stale lock file should have been removed
+    EXPECT_FALSE(fs::exists(lockFile));
+}
+
+TEST_F(IsBuildActiveTest, ActiveLockFileIsNotCleaned) {
+    // Test that isBuildActive does NOT clean up lock files held by active processes
+    Entry orthoEntry;
+    fs::path relativePath = fs::relative(orthoPath, dbPath);
+    ASSERT_TRUE(ddb::getEntry(db.get(), relativePath.string(), orthoEntry));
+
+    std::string buildPath = db->buildDirectory().string();
+    fs::path orthoOutputPath = fs::path(buildPath) / orthoEntry.hash / "cog";
+    fs::create_directories(orthoOutputPath.parent_path());
+
+    // Acquire a real build lock (simulates an active build by this process)
+    {
+        BuildLock activeLock(orthoOutputPath.string());
+        EXPECT_TRUE(activeLock.isHolding());
+
+        // isBuildActive should return true — lock is held by an active process
+        EXPECT_TRUE(ddb::isBuildActive(db.get(), relativePath.string()));
+    }
+}
+
 } // anonymous namespace


### PR DESCRIPTION
## Problem

When a build process fails or crashes, it can leave a stale `.building` lock file on disk. Subsequent build attempt: including force builds triggered by the UI's 'Retry Processing' button: were blocked because:

1. **build.cpp**: The force-retry path removed .building files without checking PID liveness, risking deletion of locks held by **active** processes (concurrent build corruption).
2. **buildlock.cpp (Linux)**: The `waitForLock=true` path unconditionally called `unlink()` before `O_EXCL` open. On Unix, `unlink()` on a file opened by another process **succeeds** (removes the directory entry while the inode survives), breaking mutual exclusion and allowing two builds to run concurrently.
3. **Registry (ObjectsManager.cs)**: The `IsBuildActive()` guard ignored the `force` flag, rejecting force builds before the C++ layer could attempt stale lock recovery.

## Fix

### build.cpp: PID-based stale lock verification
The force-retry path now calls `isLockFileStale()` (reads PID from lock file + checks process liveness) **before** removing the `.building` file. If the lock-holding process is still alive, `BuildInProgressException` is thrown even with `force=true`, including the active PID in the message for diagnostics.

### buildlock.cpp: Pure O_EXCL on Unix
Removed the unconditional `unlink()` from the Linux `waitForLock=true` path. `BuildLock` is now a pure exclusivity primitive on all platforms: it never removes existing lock files. Stale lock recovery is the caller's responsibility (build.cpp), which has access to PID liveness checks. The header documentation (`buildlock.h`) now explicitly documents the cross-platform semantics.

### Registry (ObjectsManager.cs): Separate PR
The `IsBuildActive()` guard was changed to `if (!force && ddb.IsBuildActive(...))` so that force builds bypass the .NET-level guard and reach the C++ stale lock recovery logic. See [Registry PR #333](https://github.com/DroneDB/Registry/pull/333).

## Platform Semantics

| Aspect | Windows | Linux |
|--------|---------|-------|
| `wait=true` | `CREATE_ALWAYS` (overwrites orphaned files, blocks on active handles) | `O_CREAT\|O_EXCL` (fails if file exists) |
| `wait=false` | `CREATE_NEW` (fails if file exists) | `O_CREAT\|O_EXCL` (fails if file exists) |
| Stale recovery | Kernel auto-deletes on process death (`FILE_FLAG_DELETE_ON_CLOSE`) | Caller must detect stale PIDs and remove file before retry |

## Tests Added
- `WaitMode_OrphanedLockFileOnDisk`: Platform-aware test (Windows: lock reclaimed; Linux: O_EXCL throws)
- `NoWaitMode_FailsOnOrphanedLockFile`: Both platforms reject orphaned files with wait=false
- `ForceBuildScenario_StaleLockRecovery`: Full caller-side flow (detect stale → remove → reacquire)
- All tests use realistic `PID: 99` format matching production `readPidFromLockFile` expectations