### PR TITLE
Improve COG generation and georaster masking

### DIFF
--- a/src/include/ddb.h
+++ b/src/include/ddb.h
@@ -586,9 +586,12 @@ extern "C"
                                        int bandIndex,
                                        char **output);
 
-    /** Mask orthophoto borders making them transparent
+    /** Mask orthophoto borders making them transparent.
+     * Supports 1-band rasters (greyscale ortho, thermal, DEM), 3-band 8-bit RGB and
+     * 4-band 8-bit RGBA orthophotos. Transparency is written as an internal GeoTIFF
+     * dataset mask (any pre-existing alpha band in RGBA inputs is overwritten).
      * @param input Path to input GeoTIFF
-     * @param output Path to output GeoTIFF (with alpha band)
+     * @param output Path to output GeoTIFF (with internal dataset mask)
      * @param near Tolerance in grey levels (default 15)
      * @param white If true, search for white borders instead of black
      * @return DDBERR_NONE on success, an error otherwise */

--- a/src/library/cog.cpp
+++ b/src/library/cog.cpp
@@ -69,6 +69,10 @@ namespace ddb
         // Detect and preserve nodata from source
         int hasNoData;
         GDALRasterBandH hSrcBand1 = GDALGetRasterBand(hSrcDataset, 1);
+        if (!hSrcBand1) {
+            GDALClose(hSrcDataset);
+            throw GDALException("Cannot read band 1 from " + inputGTiff);
+        }
         double srcNoData = GDALGetRasterNoDataValue(hSrcBand1, &hasNoData);
 
         // Some GDAL versions / code paths may fail to preserve a standalone

--- a/src/library/cog.cpp
+++ b/src/library/cog.cpp
@@ -68,7 +68,26 @@ namespace ddb
 
         // Detect and preserve nodata from source
         int hasNoData;
-        double srcNoData = GDALGetRasterNoDataValue(GDALGetRasterBand(hSrcDataset, 1), &hasNoData);
+        GDALRasterBandH hSrcBand1 = GDALGetRasterBand(hSrcDataset, 1);
+        double srcNoData = GDALGetRasterNoDataValue(hSrcBand1, &hasNoData);
+
+        // Some GDAL versions / code paths may fail to preserve a standalone
+        // PER_DATASET mask when a COG is produced through a warp/reprojection step
+        // (observed with GDAL 3.11.x on files produced by nearblack/maskBorders),
+        // causing masked borders to become opaque black pixels, especially with
+        // JPEG/YCbCr compression.
+        // To make COG generation deterministic
+        // across GDAL versions, when the source has a stand-alone PER_DATASET
+        // mask (not derived from an alpha band nor from a nodata value, which
+        // are handled by other code paths), we force GDALWarp to materialize
+        // the transparency as a destination alpha band. The COG driver then
+        // serializes that alpha as an internal 1-bit mask (MSK IFD) for JPEG
+        // output, preserving transparency without re-encoding alpha as JPEG.
+        const int srcMaskFlags = GDALGetMaskFlags(hSrcBand1);
+        const bool hasPerDatasetMask =
+            (srcMaskFlags & GMF_PER_DATASET) != 0 &&
+            (srcMaskFlags & GMF_ALPHA) == 0 &&
+            (srcMaskFlags & GMF_NODATA) == 0;
 
         char **targs = nullptr;
         targs = CSLAddString(targs, "-of");
@@ -101,6 +120,13 @@ namespace ddb
             } else {
                 LOGW << "Skipping nodata preservation for unsupported value: " << srcNoData;
             }
+        } else if (hasPerDatasetMask) {
+            // Materialize the source PER_DATASET mask as a destination alpha
+            // band so transparency survives the COG reprojection step. The COG
+            // driver converts the alpha back into an internal 1-bit mask for
+            // JPEG output (no alpha-in-JPEG cost) and into a 4th band for LZW.
+            LOGD << "Source has PER_DATASET mask; forcing -dstalpha to preserve transparency";
+            targs = CSLAddString(targs, "-dstalpha");
         }
 
         // We can compress to JPG if these are 8bit bands (3 or 4) and no nodata

--- a/src/library/mask.cpp
+++ b/src/library/mask.cpp
@@ -73,6 +73,23 @@ namespace ddb
                             "orthophoto); got ") + GDALGetDataTypeName(srcType));
         }
 
+        // For 4-band inputs, require that band 4 is an alpha channel. A 4-band
+        // raster where band 4 is not alpha (e.g. RGB+NIR multispectral) must go
+        // through the multispectral pipeline instead.
+        if (srcBands == 4) {
+            GDALRasterBandH hBand4 = GDALGetRasterBand(hSrcDataset, 4);
+            if (!hBand4) {
+                GDALClose(hSrcDataset);
+                throw GDALException("Cannot read band 4 from " + input);
+            }
+            if (GDALGetRasterColorInterpretation(hBand4) != GCI_AlphaBand) {
+                GDALClose(hSrcDataset);
+                throw InvalidArgsException(
+                    "4-band input must be RGBA (band 4 must be an alpha channel); "
+                    "for multispectral rasters (e.g. RGB+NIR) use the multispectral pipeline");
+            }
+        }
+
         const uint64_t pixelCount =
             static_cast<uint64_t>(srcWidth) * static_cast<uint64_t>(srcHeight);
         // With -setmask the transparency is a dataset mask (1 bit/pixel), not an

--- a/src/library/mask.cpp
+++ b/src/library/mask.cpp
@@ -6,6 +6,7 @@
 #include "logger.h"
 #include "exceptions.h"
 #include "fs.h"
+#include <cstdint>
 
 namespace ddb
 {
@@ -36,54 +37,65 @@ namespace ddb
         const int srcHeight = GDALGetRasterYSize(hSrcDataset);
         const int srcBands = GDALGetRasterCount(hSrcDataset);
 
-        const uint64_t pixelCount =
-            static_cast<uint64_t>(srcWidth) * static_cast<uint64_t>(srcHeight);
-
-        uint64_t estimatedRasterBytes = 0;
-        int maxBytesPerSample = 0;
-        bool hasUnknownDataTypeSize = false;
-
-        for (int i = 1; i <= srcBands; ++i) {
-            GDALRasterBandH hBand = GDALGetRasterBand(hSrcDataset, i);
-            if (!hBand) {
-                hasUnknownDataTypeSize = true;
-                continue;
-            }
-
-            const GDALDataType eType = GDALGetRasterDataType(hBand);
-            const int bytesPerSample = GDALGetDataTypeSizeBytes(eType);
-
-            if (bytesPerSample <= 0) {
-                hasUnknownDataTypeSize = true;
-                continue;
-            }
-
-            estimatedRasterBytes += pixelCount * static_cast<uint64_t>(bytesPerSample);
-            maxBytesPerSample = std::max(maxBytesPerSample, bytesPerSample);
+        // Supported domain:
+        //   - 1 band  any   -> greyscale ortho / thermal / DEM with black collar
+        //   - 3 bands Byte  -> RGB orthophoto with black/white collar
+        //   - 4 bands Byte  -> RGBA orthophoto (e.g. a previously-masked file being
+        //                      reprocessed); the existing alpha is overwritten by
+        //                      the new internal dataset mask.
+        // Anything else (multispectral, mixed types) is out of scope: refusing here
+        // avoids silently producing a corrupt or oversized output.
+        if (srcBands != 1 && srcBands != 3 && srcBands != 4) {
+            GDALClose(hSrcDataset);
+            throw InvalidArgsException(
+                "Mask borders supports only 1-band (DEM/thermal/greyscale), 3-band RGB "
+                "or 4-band RGBA rasters; input has " + std::to_string(srcBands) + " bands");
         }
 
-        // With -setmask the transparency is a dataset mask, not an added alpha band.
-        // Internal GeoTIFF masks are conceptually 1 bit/pixel; this is only a rough
-        // uncompressed-size estimate
+        GDALRasterBandH hBand1 = GDALGetRasterBand(hSrcDataset, 1);
+        if (!hBand1) {
+            GDALClose(hSrcDataset);
+            throw GDALException("Cannot read band 1 from " + input);
+        }
+        const GDALDataType srcType = GDALGetRasterDataType(hBand1);
+        const int bytesPerSample = GDALGetDataTypeSizeBytes(srcType);
+        if (bytesPerSample <= 0) {
+            GDALClose(hSrcDataset);
+            throw InvalidArgsException(
+                std::string("Unsupported band data type: ") + GDALGetDataTypeName(srcType));
+        }
+
+        // 3-/4-band paths are supported only for 8-bit (true RGB / RGBA orthophotos).
+        if ((srcBands == 3 || srcBands == 4) && srcType != GDT_Byte) {
+            GDALClose(hSrcDataset);
+            throw InvalidArgsException(
+                std::string("3- and 4-band masking require 8-bit Byte input (RGB/RGBA "
+                            "orthophoto); got ") + GDALGetDataTypeName(srcType));
+        }
+
+        const uint64_t pixelCount =
+            static_cast<uint64_t>(srcWidth) * static_cast<uint64_t>(srcHeight);
+        // With -setmask the transparency is a dataset mask (1 bit/pixel), not an
+        // added alpha band. This is only a rough uncompressed-size estimate used for
+        // diagnostics; the actual BigTIFF promotion is decided by BIGTIFF=IF_SAFER.
+        const uint64_t estimatedRasterBytes =
+            pixelCount * static_cast<uint64_t>(bytesPerSample) * static_cast<uint64_t>(srcBands);
         const uint64_t estimatedMaskBytes = (pixelCount + 7) / 8;
         const uint64_t estimatedBytes = estimatedRasterBytes + estimatedMaskBytes;
-
-        // Informational only. The actual BigTIFF choice is controlled by the GTiff
-        // creation option BIGTIFF=IF_SAFER below.
         const bool logBigTiffLikely = estimatedBytes > (uint64_t(4) << 30);
 
         LOGD << "Mask source: " << srcWidth << "x" << srcHeight
             << " bands=" << srcBands
-            << " maxBytesPerSample=" << maxBytesPerSample
+            << " type=" << GDALGetDataTypeName(srcType)
+            << " bytesPerSample=" << bytesPerSample
             << " estimated uncompressed raster+1bit-mask ~"
             << (estimatedBytes >> 20) << " MiB"
-            << (hasUnknownDataTypeSize ? " (data type size unknown for at least one band)" : "")
             << (logBigTiffLikely ? " (BigTIFF may be needed; final decision uses BIGTIFF=IF_SAFER)" : "");
 
         char **targs = nullptr;
 
         // IMPORTANT: use mask, not alpha.
-        // Alpha would create a 4th Byte band and make JPEG/YCBCR less straightforward.
+        // Alpha would create an extra Byte band and break JPEG/YCBCR layout.
         targs = CSLAddString(targs, "-setmask");
 
         targs = CSLAddString(targs, "-alg");
@@ -104,24 +116,62 @@ namespace ddb
         targs = CSLAddString(targs, "-of");
         targs = CSLAddString(targs, "GTiff");
 
-        // Match the source style: RGB JPEG-in-TIFF with YCbCr.
-        targs = CSLAddString(targs, "-co");
-        targs = CSLAddString(targs, "COMPRESS=JPEG");
-        targs = CSLAddString(targs, "-co");
-        targs = CSLAddString(targs, "PHOTOMETRIC=YCBCR");
-        targs = CSLAddString(targs, "-co");
-        targs = CSLAddString(targs, "JPEG_QUALITY=75");
+        // Compression policy:
+        //   * 3-band Byte (RGB ortho)  -> JPEG + YCBCR (small, fast, perceptually fine)
+        //   * 1-band Byte (greyscale)  -> JPEG + MINISBLACK
+        //   * 4-band Byte (RGBA)       -> DEFLATE + PREDICTOR=2 (JPEG can't carry the
+        //                                  alpha band; DEFLATE keeps it fast)
+        //   * 1-band integer non-Byte  -> DEFLATE + PREDICTOR=2 (horizontal)
+        //   * 1-band Float32/Float64   -> DEFLATE + PREDICTOR=3 (floating point)
+        // Lossless LZW is intentionally avoided on large orthos because it produces
+        // multi-GB intermediates and is very slow. The mask output is consumed by
+        // buildCog right after, so the only requirement is that the compressor
+        // supports the band layout/type.
+        const char *compressOpt = nullptr;
+        const char *photometricOpt = nullptr;
+        const char *predictorOpt = nullptr;
+        const char *qualityOrZlevelOpt = nullptr;
 
-        // BIGTIFF=IF_SAFER lets the GTiff driver decide whether BigTIFF is safer.
-        // The estimate logged above is informational only and does not drive this
-        // decision.
+        if (srcBands == 3) {
+            compressOpt = "COMPRESS=JPEG";
+            photometricOpt = "PHOTOMETRIC=YCBCR";
+            qualityOrZlevelOpt = "JPEG_QUALITY=75";
+        } else if (srcBands == 1 && srcType == GDT_Byte) {
+            compressOpt = "COMPRESS=JPEG";
+            photometricOpt = "PHOTOMETRIC=MINISBLACK";
+            qualityOrZlevelOpt = "JPEG_QUALITY=75";
+        } else {
+            // 4-band Byte (RGBA) and 1-band non-Byte (integers/floats) all land here.
+            compressOpt = "COMPRESS=DEFLATE";
+            // ZLEVEL=2: very fast, still gives big savings on flat-collar borders.
+            qualityOrZlevelOpt = "ZLEVEL=2";
+            predictorOpt = (srcType == GDT_Float32 || srcType == GDT_Float64)
+                               ? "PREDICTOR=3"
+                               : "PREDICTOR=2";
+        }
+
+        targs = CSLAddString(targs, "-co");
+        targs = CSLAddString(targs, compressOpt);
+        if (photometricOpt) {
+            targs = CSLAddString(targs, "-co");
+            targs = CSLAddString(targs, photometricOpt);
+        }
+        if (predictorOpt) {
+            targs = CSLAddString(targs, "-co");
+            targs = CSLAddString(targs, predictorOpt);
+        }
+        targs = CSLAddString(targs, "-co");
+        targs = CSLAddString(targs, qualityOrZlevelOpt);
+
+        // BIGTIFF=IF_SAFER lets the GTiff driver decide whether BigTIFF is needed.
+        // The estimate logged above is informational only.
         targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "BIGTIFF=IF_SAFER");
-        targs = CSLAddString(targs, "-co");
 
         // TILED + 512px blocks avoid giant-strip scratch buffers and match the COG
-        // pipeline. We do not generate overviews here; nearblack output is treated as
-        // an intermediate and overview generation is left to the build/COG pipeline.
+        // pipeline. We do not generate overviews here; mask output is treated as an
+        // intermediate and overview generation is left to the build/COG pipeline.
+        targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "TILED=YES");
         targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "BLOCKXSIZE=512");

--- a/src/library/mask.cpp
+++ b/src/library/mask.cpp
@@ -11,15 +11,21 @@ namespace ddb
 {
 
     void maskBorders(const std::string &input,
-                     const std::string &output,
-                     int nearDist,
-                     bool white,
-                     const std::string &color)
+                 const std::string &output,
+                 int nearDist,
+                 bool white,
+                 const std::string &color)
     {
-
         if (fs::exists(output)) {
             LOGD << "Output file " << output << " already exists, deleting it";
             fs::remove(output);
+        }
+
+        // Clean possible stale external mask from previous runs.
+        const std::string externalMask = output + ".msk";
+        if (fs::exists(externalMask)) {
+            LOGD << "External mask file " << externalMask << " already exists, deleting it";
+            fs::remove(externalMask);
         }
 
         GDALDatasetH hSrcDataset = GDALOpen(input.c_str(), GA_ReadOnly);
@@ -29,37 +35,65 @@ namespace ddb
         const int srcWidth = GDALGetRasterXSize(hSrcDataset);
         const int srcHeight = GDALGetRasterYSize(hSrcDataset);
         const int srcBands = GDALGetRasterCount(hSrcDataset);
-        // Rough estimate of the uncompressed output size including the alpha band
-        // we are about to add. Byte rasters dominate ortho workflows; for wider
-        // types this is still a conservative lower bound that drives the BIGTIFF
-        // decision below.
-        const uint64_t estimatedBytes =
-            static_cast<uint64_t>(srcWidth) * static_cast<uint64_t>(srcHeight) *
-            static_cast<uint64_t>(srcBands + 1);
-        // Classic TIFF caps at 4 GiB. Log when we expect to cross that line so
-        // the BIGTIFF=IF_SAFER promotion is auditable from --debug output.
-        const bool expectBigTiff = estimatedBytes > (uint64_t(4) << 30);
+
+        const uint64_t pixelCount =
+            static_cast<uint64_t>(srcWidth) * static_cast<uint64_t>(srcHeight);
+
+        uint64_t estimatedRasterBytes = 0;
+        int maxBytesPerSample = 0;
+        bool hasUnknownDataTypeSize = false;
+
+        for (int i = 1; i <= srcBands; ++i) {
+            GDALRasterBandH hBand = GDALGetRasterBand(hSrcDataset, i);
+            if (!hBand) {
+                hasUnknownDataTypeSize = true;
+                continue;
+            }
+
+            const GDALDataType eType = GDALGetRasterDataType(hBand);
+            const int bytesPerSample = GDALGetDataTypeSizeBytes(eType);
+
+            if (bytesPerSample <= 0) {
+                hasUnknownDataTypeSize = true;
+                continue;
+            }
+
+            estimatedRasterBytes += pixelCount * static_cast<uint64_t>(bytesPerSample);
+            maxBytesPerSample = std::max(maxBytesPerSample, bytesPerSample);
+        }
+
+        // With -setmask the transparency is a dataset mask, not an added alpha band.
+        // Internal GeoTIFF masks are conceptually 1 bit/pixel; this is only a rough
+        // uncompressed-size estimate
+        const uint64_t estimatedMaskBytes = (pixelCount + 7) / 8;
+        const uint64_t estimatedBytes = estimatedRasterBytes + estimatedMaskBytes;
+
+        // Informational only. The actual BigTIFF choice is controlled by the GTiff
+        // creation option BIGTIFF=IF_SAFER below.
+        const bool logBigTiffLikely = estimatedBytes > (uint64_t(4) << 30);
+
         LOGD << "Mask source: " << srcWidth << "x" << srcHeight
-             << " bands=" << srcBands
-             << " estimated output ~" << (estimatedBytes >> 20) << " MiB"
-             << (expectBigTiff ? " (BIGTIFF expected)" : "");
+            << " bands=" << srcBands
+            << " maxBytesPerSample=" << maxBytesPerSample
+            << " estimated uncompressed raster+1bit-mask ~"
+            << (estimatedBytes >> 20) << " MiB"
+            << (hasUnknownDataTypeSize ? " (data type size unknown for at least one band)" : "")
+            << (logBigTiffLikely ? " (BigTIFF may be needed; final decision uses BIGTIFF=IF_SAFER)" : "");
 
         char **targs = nullptr;
 
-        // Set alpha band for transparency
-        targs = CSLAddString(targs, "-setalpha");
+        // IMPORTANT: use mask, not alpha.
+        // Alpha would create a 4th Byte band and make JPEG/YCBCR less straightforward.
+        targs = CSLAddString(targs, "-setmask");
 
-        // Use floodfill algorithm - requires GDAL >= 3.8.
-        // DroneDB pins GDAL via vcpkg, so this is always satisfied.
-        // If building against a system GDAL, ensure version >= 3.8.
         targs = CSLAddString(targs, "-alg");
         targs = CSLAddString(targs, "floodfill");
+        // Faster alternative but doesn't handle concave collars
+        // targs = CSLAddString(targs, "twopasses");
 
-        // Tolerance
         targs = CSLAddString(targs, "-near");
         targs = CSLAddString(targs, std::to_string(nearDist).c_str());
 
-        // Color mode
         if (!color.empty()) {
             targs = CSLAddString(targs, "-color");
             targs = CSLAddString(targs, color.c_str());
@@ -67,43 +101,67 @@ namespace ddb
             targs = CSLAddString(targs, "-white");
         }
 
-        // Output format and compression.
-        // BIGTIFF=IF_SAFER auto-promotes to BigTIFF when the predicted size
-        // approaches the 4 GiB classic-TIFF limit (keeps small outputs classic).
-        // TILED + 512px blocks avoid the giant-strip scratch buffers that cause
-        // TIFFAppendToStrip failures on large orthos and match the COG pipeline.
-        // NUM_THREADS=ALL_CPUS speeds up LZW encoding on large rasters.
-        // Note: we intentionally do NOT generate overviews here; nearblack output
-        // is treated as an intermediate. Overview generation is left to the
-        // build/COG pipeline (see buildCog).
         targs = CSLAddString(targs, "-of");
         targs = CSLAddString(targs, "GTiff");
+
+        // Match the source style: RGB JPEG-in-TIFF with YCbCr.
         targs = CSLAddString(targs, "-co");
-        targs = CSLAddString(targs, "COMPRESS=LZW");
+        targs = CSLAddString(targs, "COMPRESS=JPEG");
         targs = CSLAddString(targs, "-co");
-        targs = CSLAddString(targs, "PREDICTOR=2");
+        targs = CSLAddString(targs, "PHOTOMETRIC=YCBCR");
+        targs = CSLAddString(targs, "-co");
+        targs = CSLAddString(targs, "JPEG_QUALITY=75");
+
+        // BIGTIFF=IF_SAFER lets the GTiff driver decide whether BigTIFF is safer.
+        // The estimate logged above is informational only and does not drive this
+        // decision.
         targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "BIGTIFF=IF_SAFER");
         targs = CSLAddString(targs, "-co");
+
+        // TILED + 512px blocks avoid giant-strip scratch buffers and match the COG
+        // pipeline. We do not generate overviews here; nearblack output is treated as
+        // an intermediate and overview generation is left to the build/COG pipeline.
         targs = CSLAddString(targs, "TILED=YES");
         targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "BLOCKXSIZE=512");
         targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "BLOCKYSIZE=512");
+
         targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "NUM_THREADS=ALL_CPUS");
 
         int bUsageError = FALSE;
+
+        // Force internal GeoTIFF mask instead of .msk sidecar, especially for GDAL < 3.9.
+        const char *prevInternalMask =
+            CPLGetThreadLocalConfigOption("GDAL_TIFF_INTERNAL_MASK", nullptr);
+        const std::string prevInternalMaskValue =
+            prevInternalMask ? prevInternalMask : "";
+
+        CPLSetThreadLocalConfigOption("GDAL_TIFF_INTERNAL_MASK", "YES");
+
         GDALNearblackOptions *psOptions = GDALNearblackOptionsNew(targs, nullptr);
         CSLDestroy(targs);
 
         if (!psOptions) {
+            CPLSetThreadLocalConfigOption(
+                "GDAL_TIFF_INTERNAL_MASK",
+                prevInternalMask ? prevInternalMaskValue.c_str() : nullptr
+            );
             GDALClose(hSrcDataset);
             throw GDALException("Failed to create nearblack options");
         }
 
-        GDALDatasetH hOutDataset = GDALNearblack(output.c_str(), nullptr, hSrcDataset, psOptions, &bUsageError);
+        GDALDatasetH hOutDataset =
+            GDALNearblack(output.c_str(), nullptr, hSrcDataset, psOptions, &bUsageError);
+
         GDALNearblackOptionsFree(psOptions);
+
+        CPLSetThreadLocalConfigOption(
+            "GDAL_TIFF_INTERNAL_MASK",
+            prevInternalMask ? prevInternalMaskValue.c_str() : nullptr
+        );
 
         if (bUsageError) {
             GDALClose(hSrcDataset);

--- a/src/library/mask.cpp
+++ b/src/library/mask.cpp
@@ -26,6 +26,24 @@ namespace ddb
         if (!hSrcDataset)
             throw GDALException("Cannot open " + input + " for reading");
 
+        const int srcWidth = GDALGetRasterXSize(hSrcDataset);
+        const int srcHeight = GDALGetRasterYSize(hSrcDataset);
+        const int srcBands = GDALGetRasterCount(hSrcDataset);
+        // Rough estimate of the uncompressed output size including the alpha band
+        // we are about to add. Byte rasters dominate ortho workflows; for wider
+        // types this is still a conservative lower bound that drives the BIGTIFF
+        // decision below.
+        const uint64_t estimatedBytes =
+            static_cast<uint64_t>(srcWidth) * static_cast<uint64_t>(srcHeight) *
+            static_cast<uint64_t>(srcBands + 1);
+        // Classic TIFF caps at 4 GiB. Log when we expect to cross that line so
+        // the BIGTIFF=IF_SAFER promotion is auditable from --debug output.
+        const bool expectBigTiff = estimatedBytes > (uint64_t(4) << 30);
+        LOGD << "Mask source: " << srcWidth << "x" << srcHeight
+             << " bands=" << srcBands
+             << " estimated output ~" << (estimatedBytes >> 20) << " MiB"
+             << (expectBigTiff ? " (BIGTIFF expected)" : "");
+
         char **targs = nullptr;
 
         // Set alpha band for transparency
@@ -49,13 +67,31 @@ namespace ddb
             targs = CSLAddString(targs, "-white");
         }
 
-        // Output format and compression
+        // Output format and compression.
+        // BIGTIFF=IF_SAFER auto-promotes to BigTIFF when the predicted size
+        // approaches the 4 GiB classic-TIFF limit (keeps small outputs classic).
+        // TILED + 512px blocks avoid the giant-strip scratch buffers that cause
+        // TIFFAppendToStrip failures on large orthos and match the COG pipeline.
+        // NUM_THREADS=ALL_CPUS speeds up LZW encoding on large rasters.
+        // Note: we intentionally do NOT generate overviews here; nearblack output
+        // is treated as an intermediate. Overview generation is left to the
+        // build/COG pipeline (see buildCog).
         targs = CSLAddString(targs, "-of");
         targs = CSLAddString(targs, "GTiff");
         targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "COMPRESS=LZW");
         targs = CSLAddString(targs, "-co");
         targs = CSLAddString(targs, "PREDICTOR=2");
+        targs = CSLAddString(targs, "-co");
+        targs = CSLAddString(targs, "BIGTIFF=IF_SAFER");
+        targs = CSLAddString(targs, "-co");
+        targs = CSLAddString(targs, "TILED=YES");
+        targs = CSLAddString(targs, "-co");
+        targs = CSLAddString(targs, "BLOCKXSIZE=512");
+        targs = CSLAddString(targs, "-co");
+        targs = CSLAddString(targs, "BLOCKYSIZE=512");
+        targs = CSLAddString(targs, "-co");
+        targs = CSLAddString(targs, "NUM_THREADS=ALL_CPUS");
 
         int bUsageError = FALSE;
         GDALNearblackOptions *psOptions = GDALNearblackOptionsNew(targs, nullptr);

--- a/tests/mask_cog_test.cpp
+++ b/tests/mask_cog_test.cpp
@@ -1,0 +1,223 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "gtest/gtest.h"
+#include "test.h"
+#include "testarea.h"
+
+#include "cog.h"
+#include "mask.h"
+#include "ddb.h"
+#include "exceptions.h"
+#include "gdal_inc.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+using namespace ddb;
+
+// ---------------------------------------------------------------------------
+// Helper: create a small synthetic RGB GeoTIFF with a black border collar.
+// The centre pixels are set to (128, 64, 32); the outer border ring is black
+// (0, 0, 0). EPSG:32632 (UTM Zone 32N) is used so buildCog can reproject.
+// ---------------------------------------------------------------------------
+static fs::path createRgbWithBlackBorder(const fs::path &path,
+                                         int w = 64, int h = 64,
+                                         int borderPx = 8)
+{
+    GDALDriverH drv = GDALGetDriverByName("GTiff");
+    if (!drv) throw std::runtime_error("GTiff driver not available");
+
+    GDALDatasetH hDs = GDALCreate(drv, path.string().c_str(),
+                                   w, h, 3, GDT_Byte, nullptr);
+    if (!hDs) throw std::runtime_error("Cannot create test raster");
+
+    // Minimal georeference in EPSG:32632 so the COG builder can reproject.
+    double gt[6] = {500000.0, 1.0, 0.0, 4500000.0, 0.0, -1.0};
+    GDALSetGeoTransform(hDs, gt);
+
+    OGRSpatialReferenceH srs = OSRNewSpatialReference(nullptr);
+    OSRImportFromEPSG(srs, 32632);
+    char *wkt = nullptr;
+    OSRExportToWkt(srs, &wkt);
+    GDALSetProjection(hDs, wkt);
+    CPLFree(wkt);
+    OSRDestroySpatialReference(srs);
+
+    // Fill each band: border pixels = 0 (black collar), interior = colour value.
+    const uint8_t colours[3] = {128, 64, 32};
+    std::vector<uint8_t> row(static_cast<size_t>(w));
+
+    for (int b = 1; b <= 3; b++) {
+        GDALRasterBandH hBand = GDALGetRasterBand(hDs, b);
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                bool isBorder = (x < borderPx || x >= w - borderPx ||
+                                 y < borderPx || y >= h - borderPx);
+                row[static_cast<size_t>(x)] = isBorder ? 0 : colours[b - 1];
+            }
+            GDALRasterIO(hBand, GF_Write, 0, y, w, 1,
+                         row.data(), w, 1, GDT_Byte, 0, 0);
+        }
+    }
+
+    GDALFlushCache(hDs);
+    GDALClose(hDs);
+    return path;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create a 4-band Byte GeoTIFF where band 4 has NO alpha colour
+// interpretation (simulating an RGB+NIR multispectral raster).
+// ---------------------------------------------------------------------------
+static fs::path createFourBandNonAlpha(const fs::path &path)
+{
+    GDALDriverH drv = GDALGetDriverByName("GTiff");
+    if (!drv) throw std::runtime_error("GTiff driver not available");
+
+    GDALDatasetH hDs = GDALCreate(drv, path.string().c_str(),
+                                   32, 32, 4, GDT_Byte, nullptr);
+    if (!hDs) throw std::runtime_error("Cannot create test raster");
+
+    // Bands 1-4: set to GCI_GrayIndex (or leave default = undefined).
+    // Deliberately do NOT set band 4 to GCI_AlphaBand.
+    for (int b = 1; b <= 4; b++) {
+        GDALRasterBandH hBand = GDALGetRasterBand(hDs, b);
+        GDALSetRasterColorInterpretation(hBand, GCI_GrayIndex);
+    }
+
+    double gt[6] = {500000.0, 1.0, 0.0, 4500000.0, 0.0, -1.0};
+    GDALSetGeoTransform(hDs, gt);
+
+    OGRSpatialReferenceH srs = OSRNewSpatialReference(nullptr);
+    OSRImportFromEPSG(srs, 32632);
+    char *wkt = nullptr;
+    OSRExportToWkt(srs, &wkt);
+    GDALSetProjection(hDs, wkt);
+    CPLFree(wkt);
+    OSRDestroySpatialReference(srs);
+
+    GDALFlushCache(hDs);
+    GDALClose(hDs);
+    return path;
+}
+
+// ===========================================================================
+// maskBorders tests
+// ===========================================================================
+
+TEST(mask, rejectsFourBandNonAlpha) {
+    TestArea ta(TEST_NAME);
+    fs::path input = createFourBandNonAlpha(ta.getPath("4band_nir.tif"));
+    fs::path output = ta.getPath("4band_nir_masked.tif");
+
+    EXPECT_THROW(
+        ddb::maskBorders(input.string(), output.string()),
+        InvalidArgsException
+    ) << "4-band input without an alpha band should be rejected";
+}
+
+TEST(mask, acceptsFourBandWithAlpha) {
+    TestArea ta(TEST_NAME);
+
+    // Build a 4-band RGBA raster (band 4 = GCI_AlphaBand).
+    GDALDriverH drv = GDALGetDriverByName("GTiff");
+    ASSERT_NE(drv, nullptr);
+    fs::path input = ta.getPath("rgba_input.tif");
+    GDALDatasetH hDs = GDALCreate(drv, input.string().c_str(),
+                                   64, 64, 4, GDT_Byte, nullptr);
+    ASSERT_NE(hDs, nullptr);
+
+    double gt[6] = {500000.0, 1.0, 0.0, 4500000.0, 0.0, -1.0};
+    GDALSetGeoTransform(hDs, gt);
+    OGRSpatialReferenceH srs = OSRNewSpatialReference(nullptr);
+    OSRImportFromEPSG(srs, 32632);
+    char *wkt = nullptr;
+    OSRExportToWkt(srs, &wkt);
+    GDALSetProjection(hDs, wkt);
+    CPLFree(wkt);
+    OSRDestroySpatialReference(srs);
+
+    // Mark band 4 as alpha and fill with full-opacity (255).
+    GDALRasterBandH hBand4 = GDALGetRasterBand(hDs, 4);
+    GDALSetRasterColorInterpretation(hBand4, GCI_AlphaBand);
+    std::vector<uint8_t> row(64, 255);
+    for (int y = 0; y < 64; y++)
+        GDALRasterIO(hBand4, GF_Write, 0, y, 64, 1, row.data(), 64, 1, GDT_Byte, 0, 0);
+
+    GDALFlushCache(hDs);
+    GDALClose(hDs);
+
+    fs::path output = ta.getPath("rgba_masked.tif");
+    EXPECT_NO_THROW(ddb::maskBorders(input.string(), output.string()))
+        << "4-band RGBA input should be accepted by maskBorders";
+    EXPECT_TRUE(fs::exists(output));
+}
+
+// ===========================================================================
+// COG regression: PER_DATASET mask must be preserved after buildCog
+// ===========================================================================
+
+TEST(mask, cogPreservesPerDatasetMask) {
+    TestArea ta(TEST_NAME);
+
+    // 1. Create a small RGB raster with a black border collar.
+    fs::path rgbInput = createRgbWithBlackBorder(ta.getPath("rgb_input.tif"));
+
+    // 2. Run maskBorders -> produces an internal PER_DATASET mask (dataset mask,
+    //    not an alpha band) via nearblack -setmask.
+    fs::path maskedGtiff = ta.getPath("rgb_masked.tif");
+    ASSERT_NO_THROW(ddb::maskBorders(rgbInput.string(), maskedGtiff.string()));
+    ASSERT_TRUE(fs::exists(maskedGtiff));
+
+    // Sanity: the intermediate GeoTIFF must carry a stand-alone PER_DATASET mask.
+    {
+        GDALDatasetH hDs = GDALOpen(maskedGtiff.string().c_str(), GA_ReadOnly);
+        ASSERT_NE(hDs, nullptr);
+        GDALRasterBandH hBand1 = GDALGetRasterBand(hDs, 1);
+        ASSERT_NE(hBand1, nullptr);
+        const int maskFlags = GDALGetMaskFlags(hBand1);
+        GDALClose(hDs);
+
+        const bool hasPerDatasetMask =
+            (maskFlags & GMF_PER_DATASET) != 0 &&
+            (maskFlags & GMF_ALPHA) == 0 &&
+            (maskFlags & GMF_NODATA) == 0;
+        EXPECT_TRUE(hasPerDatasetMask)
+            << "maskBorders output should carry a PER_DATASET (non-alpha) mask; "
+               "got mask flags = " << maskFlags;
+    }
+
+    // 3. Build COG from the masked intermediate.
+    fs::path cogOutput = ta.getPath("rgb_cog.tif");
+    ASSERT_NO_THROW(ddb::buildCog(maskedGtiff.string(), cogOutput.string()));
+    ASSERT_TRUE(fs::exists(cogOutput));
+
+    // 4. The COG must expose transparency (alpha band or PER_DATASET mask).
+    //    buildCog converts the PER_DATASET mask to a -dstalpha during the warp
+    //    step, so the COG output carries an alpha band (GMF_ALPHA | GMF_PER_DATASET).
+    {
+        GDALDatasetH hCog = GDALOpen(cogOutput.string().c_str(), GA_ReadOnly);
+        ASSERT_NE(hCog, nullptr);
+
+        GDALRasterBandH hBand1 = GDALGetRasterBand(hCog, 1);
+        ASSERT_NE(hBand1, nullptr);
+        const int maskFlags = GDALGetMaskFlags(hBand1);
+        const bool hasTransparency =
+            (maskFlags & GMF_ALPHA) != 0 ||
+            ((maskFlags & GMF_PER_DATASET) != 0 &&
+             (maskFlags & GMF_NODATA) == 0 &&
+             GDALGetRasterCount(hCog) > 3);
+        GDALClose(hCog);
+
+        EXPECT_TRUE(hasTransparency)
+            << "COG built from a PER_DATASET-masked raster must preserve "
+               "transparency; got mask flags = " << maskFlags;
+    }
+}
+
+} // namespace

--- a/tests/mask_cog_test.cpp
+++ b/tests/mask_cog_test.cpp
@@ -197,9 +197,15 @@ TEST(mask, cogPreservesPerDatasetMask) {
     ASSERT_NO_THROW(ddb::buildCog(maskedGtiff.string(), cogOutput.string()));
     ASSERT_TRUE(fs::exists(cogOutput));
 
-    // 4. The COG must expose transparency (alpha band or PER_DATASET mask).
-    //    buildCog converts the PER_DATASET mask to a -dstalpha during the warp
-    //    step, so the COG output carries an alpha band (GMF_ALPHA | GMF_PER_DATASET).
+    // 4. The COG must expose transparency. Depending on the GDAL version and
+    //    COG driver behaviour the transparency may appear as:
+    //    a) An explicit alpha band (GMF_ALPHA set), or
+    //    b) A stand-alone PER_DATASET dataset mask (GMF_PER_DATASET set,
+    //       GMF_ALL_VALID NOT set, GMF_NODATA NOT set).
+    //    GDAL 3.11 with the COG driver converts the -dstalpha alpha channel
+    //    to an internal mask IFD for JPEG output, resulting in a PER_DATASET
+    //    mask rather than an alpha band on readback. Checking only for
+    //    GMF_ALPHA would produce a false-negative on that version.
     {
         GDALDatasetH hCog = GDALOpen(cogOutput.string().c_str(), GA_ReadOnly);
         ASSERT_NE(hCog, nullptr);
@@ -210,8 +216,8 @@ TEST(mask, cogPreservesPerDatasetMask) {
         const bool hasTransparency =
             (maskFlags & GMF_ALPHA) != 0 ||
             ((maskFlags & GMF_PER_DATASET) != 0 &&
-             (maskFlags & GMF_NODATA) == 0 &&
-             GDALGetRasterCount(hCog) > 3);
+             (maskFlags & GMF_ALL_VALID) == 0 &&
+             (maskFlags & GMF_NODATA) == 0);
         GDALClose(hCog);
 
         EXPECT_TRUE(hasTransparency)


### PR DESCRIPTION
## Added BigTIFF support in the mask command

This PR extends the mask command (and the underlying maskBorders function) with several improvements needed to handle large aerial orthophotos reliably.

### Changes

#### BigTIFF support (mask.cpp)
- The output GeoTIFF is written with BIGTIFF=IF_SAFER, letting the GTiff driver automatically promote to BigTIFF when the file size would exceed 4 GiB. This removes the previous silent failure on large orthos.
- An uncompressed-size estimate (raster bytes + 1-bit mask bytes) is logged as a diagnostic hint; the actual BigTIFF decision is always deferred to BIGTIFF=IF_SAFER.

#### Mask mode switch: -setalpha → -setmask
- Nearblack is now called with -setmask instead of -setalpha. This writes transparency as an internal **dataset mask** (1-bit per pixel) rather than adding an extra Byte alpha band.
- Rationale: an alpha band forces the output to 4 channels, which breaks COMPRESS=JPEG / PHOTOMETRIC=YCBCR (YCbCr requires exactly 3 bands). Using a dataset mask keeps the band layout unchanged and lets BuildCog correctly materialise the transparency during the warp step.

#### Conditional compression policy (mask.cpp)
| Input | Compression |
|---|---|
| 3-band Byte (RGB ortho) | JPEG + YCBCR |
| 1-band Byte (greyscale / thermal) | JPEG + MINISBLACK |
| 4-band Byte (RGBA) + 1-band non-Byte (DEMs, floats) | DEFLATE + PREDICTOR |

Previously all outputs used a hardcoded JPEG/YCBCR/Q=75 regardless of band count or data type, which would silently fail for non-RGB or non-8-bit inputs.

#### Input validation (mask.cpp)
- 4-band inputs now require band 4 to have GCI_AlphaBand colour interpretation. RGB+NIR multispectral rasters (band 4 is not alpha) are explicitly rejected with a clear error message directing users to the multispectral pipeline.

#### COG transparency preservation (cog.cpp)
- When the source has a stand-alone PER_DATASET mask (produced by maskBorders), BuildCog forces -dstalpha in the GDALWarp step. This makes COG generation deterministic across GDAL versions (GDAL 3.11.x was observed to drop the mask during warp/reprojection with JPEG/YCbCr).
- Added a null check for hSrcBand1 before calling GDALGetRasterNoDataValue / GDALGetMaskFlags.

### Tests
- tests/mask_cog_test.cpp (new):
  - Verifies that a 4-band raster without GCI_AlphaBand is rejected by maskBorders.
  - Verifies that a proper 4-band RGBA raster is accepted.
  - Regression test: creates a small RGB GeoTIFF with a black border collar → runs maskBorders → checks the intermediate carries a PER_DATASET mask → runs BuildCog → asserts the COG preserves transparency.