### PR TITLE
Improve 3dtiles heuristics

### DIFF
--- a/apps/cmd/tiles3d.cpp
+++ b/apps/cmd/tiles3d.cpp
@@ -4,6 +4,7 @@
 
 #include "include/tiles3d.h"
 
+#include <cstdlib>
 #include <iostream>
 #include <optional>
 
@@ -26,7 +27,8 @@ namespace cmd
     ("lon", "Longitude of the model origin (WGS84). With --lat, forces a georeferenced tileset", cxxopts::value<double>())
     ("alt", "Altitude of the model origin in meters (used with --lat/--lon)", cxxopts::value<double>()->default_value("0"))
     ("local", "Force a non-georeferenced (local) tileset, skipping sidecar auto-detection", cxxopts::value<bool>()->default_value("false"))
-    ("overwrite", "Overwrite the output directory if it exists", cxxopts::value<bool>()->default_value("false"));
+    ("overwrite", "Overwrite the output directory if it exists", cxxopts::value<bool>()->default_value("false"))
+    ("force-defaults", "Skip face-count heuristic and use default Obj2Tiles parameters (divisions=3, lods=3, octree=true) for testing", cxxopts::value<bool>()->default_value("false"));
         // clang-format on
         opts.parse_positional({"input", "output"});
     }
@@ -53,6 +55,18 @@ namespace cmd
 
         const bool overwrite = opts["overwrite"].as<bool>();
         const bool forceLocal = opts["local"].as<bool>();
+        const bool forceDefaults = opts["force-defaults"].as<bool>();
+
+        // --force-defaults sets an environment variable that buildModel3DTiles() checks
+        // to skip the face-count heuristic and use hardcoded default parameters instead.
+        if (forceDefaults)
+        {
+#ifdef _WIN32
+            _putenv_s("DDB_OBJ2TILES_FORCE_DEFAULTS", "1");
+#else
+            setenv("DDB_OBJ2TILES_FORCE_DEFAULTS", "1", 1);
+#endif
+        }
 
         // Explicit --lat/--lon override sidecar auto-detection; --local forces local
         // mode; otherwise georeferencing is auto-detected from sidecars next to the input.

--- a/src/include/3d.h
+++ b/src/include/3d.h
@@ -4,6 +4,7 @@
 #ifndef _3D_H
 #define _3D_H
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include "ddb_export.h"

--- a/src/include/3d.h
+++ b/src/include/3d.h
@@ -11,6 +11,7 @@
 #include <nxs.h>
 #endif
 #include <vector>
+#include "obj2tiles_runner.h"
 
 namespace ddb
 {
@@ -91,6 +92,7 @@ namespace ddb
         bool hasBounds = false;                     ///< True when the box below is valid.
         double minX = 0.0, minY = 0.0, minZ = 0.0;  ///< Minimum corner (local meters).
         double maxX = 0.0, maxY = 0.0, maxZ = 0.0;  ///< Maximum corner (local meters).
+        uint64_t faceCount = 0;                     ///< Total number of mesh faces (triangles after triangulation).
     };
 
     /**
@@ -107,6 +109,20 @@ namespace ddb
      * @return true when a non-empty bounding box was computed, false otherwise.
      */
     DDB_DLL bool getModelInfo(const std::string &inputModel, ModelInfo &info);
+
+    /**
+     * @brief Compute Obj2Tiles parameters based on model face count.
+     *
+     * Maps info.faceCount to a (divisions, lods, octree) band from the spec.
+     * The resulting tile-hierarchy depth (divisions + lods - 1 when octree)
+     * is always <= MAX_TILE_DEPTH (6, i.e. <= 4096 finest-LOD tiles),
+     * regardless of faceCount, so pathologically large models cannot make
+     * Obj2Tiles produce an unbounded number of b3dm files.
+     *
+     * @param info Model info with faceCount populated by getModelInfo().
+     * @return Obj2TilesOptions with heuristic-based divisions/lods/octree.
+     */
+    DDB_DLL obj2tiles::Obj2TilesOptions computeObj2TilesOpts(const ModelInfo &info);
 
     DDB_DLL std::vector<std::string> getObjDependencies(const std::string &obj);
     DDB_DLL std::vector<std::string> getGltfDependencies(const std::string &gltf);

--- a/src/library/3d.cpp
+++ b/src/library/3d.cpp
@@ -620,4 +620,82 @@ std::vector<std::string> getGltfDependencies(const std::string& gltf) {
     }
 }
 
+/**
+ * @brief Compute Obj2Tiles parameters based on model face count.
+ *
+ * Threshold bands (from spec §4):
+ * - Tiny:    < 10K faces  → lods=1, divisions=0, octree=false  (depth=0,   ≤ 1 tile)
+ * - Small:   10K–50K     → lods=2, divisions=0, octree=true   (depth=1,   ≤ 4 tiles)
+ * - Medium:  50K–200K    → lods=2, divisions=1, octree=true   (depth=2,  ≤ 16 tiles)
+ * - Large:   200K–750K   → lods=3, divisions=1, octree=true   (depth=3,  ≤ 64 tiles)
+ * - XL:      750K–3M     → lods=3, divisions=2, octree=true   (depth=4, ≤ 256 tiles)
+ * - XXL:     3M–12M      → lods=4, divisions=2, octree=true   (depth=5, ≤ 1024 tiles)
+ * - Massive: > 12M       → lods=4, divisions=3, octree=true   (depth=6, ≤ 4096 tiles, hard cap)
+ */
+const int MAX_TILE_DEPTH = 6;
+
+obj2tiles::Obj2TilesOptions computeObj2TilesOpts(const ModelInfo& info) {
+    obj2tiles::Obj2TilesOptions opts;
+
+    uint64_t faces = info.faceCount;
+    bool octree = true;
+    int lods = 3;
+    int divisions = 2;
+
+    if (faces < 10000) {
+        // Tiny: < 10K faces
+        lods = 1;
+        divisions = 0;
+        octree = false;
+    } else if (faces < 50000) {
+        // Small: 10K–50K
+        lods = 2;
+        divisions = 0;
+    } else if (faces < 200000) {
+        // Medium: 50K–200K
+        lods = 2;
+        divisions = 1;
+    } else if (faces < 750000) {
+        // Large: 200K–750K
+        lods = 3;
+        divisions = 1;
+    } else if (faces < 3000000) {
+        // XL: 750K–3M
+        lods = 3;
+        divisions = 2;
+    } else if (faces < 12000000) {
+        // XXL: 3M–12M
+        lods = 4;
+        divisions = 2;
+    } else {
+        // Massive: > 12M (hard cap at depth 6)
+        lods = 4;
+        divisions = 3;
+    }
+
+    // Clamp: ensure depth never exceeds MAX_TILE_DEPTH
+    int depth = octree ? (lods + divisions - 1) : divisions;
+    if (octree && depth > MAX_TILE_DEPTH) {
+        // Reduce lods first (preserves finer base grid, coarser LOD hierarchy)
+        lods = MAX_TILE_DEPTH - divisions + 1;
+        if (lods < 1) lods = 1;
+    }
+
+    opts.lods = lods;
+    opts.divisions = divisions;
+    opts.octree = octree;
+
+    // Preserve texture defaults (same as current hardcoded values)
+    opts.textureFormat = "Ktx2";
+    opts.ktx2Quality = 192;
+    opts.splitStrategy = "VertexMedian";
+
+    LOGD << "computeObj2TilesOpts: faces=" << faces
+         << " → lods=" << lods << ", divisions=" << divisions
+         << ", octree=" << (octree ? "true" : "false")
+         << ", depth=" << (octree ? (lods + divisions - 1) : divisions);
+
+    return opts;
+}
+
 }  // namespace ddb

--- a/src/library/3d.cpp
+++ b/src/library/3d.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 #include "3d.h"
 
+#include <cstdlib>
 #include <fstream>
 #include <optional>
 #include <regex>
@@ -441,19 +442,42 @@ std::string buildModel3DTiles(const std::string& inputObj, const std::string& ou
     io::assureIsRemoved(tempOut);
     io::assureFolderExists(tempOut);
 
+    // Compute Obj2Tiles parameters based on model face count.
+    // Face count → (divisions, lods, octree) heuristic selects the right tile
+    // hierarchy depth for the model's complexity. Small models (<10K faces) get
+    // a single tile at the finest LOD; large models get progressively deeper
+    // splits, hard-capped at depth 6 (≤ 4096 finest-LOD tiles).
+    // --force-defaults / DDB_OBJ2TILES_FORCE_DEFAULTS env var skips the heuristic
+    // and uses hardcoded defaults for testing/debugging.
+    const bool forceDefaults = [] {
+        const char* env = std::getenv("DDB_OBJ2TILES_FORCE_DEFAULTS");
+        return env && env[0] != '0' && env[0] != '\0';
+    }();
+
+    ModelInfo info;
     obj2tiles::Obj2TilesOptions opts;
-    // Octree mode: each LOD gets an extra subdivision level,
-    // producing a real tile hierarchy (smaller, view-dependent b3dm tiles) instead of
-    // the same tile count per LOD - closer to Nexus-style progressive streaming.
-    opts.octree = true;
-    // 3 levels of binary splitting per axis as the base grid ((2^3)^2 = 64 tiles),
-    // with octree mode adding further depth to finer LODs - a good balance between
-    // per-tile granularity/streaming and per-tile overhead for aerial datasets.
-    opts.divisions = 3;
-    // KTX2 (Basis Universal) texture atlases cut GPU/VRAM usage ~4-8x vs JPEG at the
-    // cost of requiring Obj2Tiles >= v1.6.0 with the bundled libktx native library
-    // (see scripts/download-obj2tiles.{ps1,sh}). VertexMedian gives the most balanced
-    // tile sizes for non-uniform geometry (requires Obj2Tiles >= v1.4.0).
+    if (forceDefaults) {
+        // --force-defaults: skip heuristic, use hardcoded defaults (current behavior)
+        opts.octree = true;
+        opts.divisions = 3;
+        opts.lods = 3;
+        LOGD << "DDB_OBJ2TILES_FORCE_DEFAULTS set — skipping heuristic, "
+             << "using defaults (divisions=3, lods=3, octree=true)";
+    } else if (getModelInfo(actualInputObj, info)) {
+        opts = computeObj2TilesOpts(info);
+        LOGD << "Model " << actualInputObj << " has " << (info.faceCount / 1000)
+             << "K faces → divisions=" << opts.divisions << ", lods=" << opts.lods
+             << ", octree=" << (opts.octree ? "true" : "false");
+    } else {
+        // Fallback: preserve current hardcoded behavior when model stats unavailable.
+        // Matches the "XXL" band (depth = 3 + 3 - 1 = 5, ≤ 1024 finest-LOD tiles).
+        opts.octree = true;
+        opts.divisions = 3;
+        opts.lods = 3;
+        LOGD << "Could not determine face count for " << actualInputObj
+             << " — using fallback (divisions=3, lods=3, octree=true)";
+    }
+    // Preserve texture defaults (heuristic sets divisions/lods/octree only)
     opts.textureFormat = "Ktx2";
     opts.ktx2Quality = 192;
     opts.splitStrategy = "VertexMedian";

--- a/src/library/3d.cpp
+++ b/src/library/3d.cpp
@@ -651,10 +651,19 @@ std::vector<std::string> getGltfDependencies(const std::string& gltf) {
  * - Tiny:    < 10K faces  → lods=1, divisions=0, octree=false  (depth=0,   ≤ 1 tile)
  * - Small:   10K–50K     → lods=2, divisions=0, octree=true   (depth=1,   ≤ 4 tiles)
  * - Medium:  50K–200K    → lods=2, divisions=1, octree=true   (depth=2,  ≤ 16 tiles)
- * - Large:   200K–750K   → lods=3, divisions=1, octree=true   (depth=3,  ≤ 64 tiles)
- * - XL:      750K–3M     → lods=3, divisions=2, octree=true   (depth=4, ≤ 256 tiles)
+ * - Large:   200K–750K   → lods=3, divisions=2, octree=true   (depth=4, ≤ 256 tiles)
+ * - XL:      750K–3M     → lods=3, divisions=3, octree=true   (depth=5, ≤ 1024 tiles)
  * - XXL:     3M–12M      → lods=4, divisions=2, octree=true   (depth=5, ≤ 1024 tiles)
  * - Massive: > 12M       → lods=4, divisions=3, octree=true   (depth=6, ≤ 4096 tiles, hard cap)
+ *
+ * Note: Base-grid tiles (divisions) cull independently
+ * per-tile, while LOD-hierarchy depth only adds refinement steps on top of the same
+ * base grid. Favoring divisions over lods in the mid-to-large range yields finer
+ * per-tile download granularity for the same total depth budget. Kept face-count as
+ * the sole signal (not model area) because area is only meaningful in physical units
+ * for georeferenced photogrammetry output; generic user-uploaded models (arbitrary
+ * units, arbitrary orientation, orbit-viewed) would make an area-based divisions
+ * calculation actively harmful.
  */
 const int MAX_TILE_DEPTH = 6;
 
@@ -682,11 +691,11 @@ obj2tiles::Obj2TilesOptions computeObj2TilesOpts(const ModelInfo& info) {
     } else if (faces < 750000) {
         // Large: 200K–750K
         lods = 3;
-        divisions = 1;
+        divisions = 2;
     } else if (faces < 3000000) {
         // XL: 750K–3M
         lods = 3;
-        divisions = 2;
+        divisions = 3;
     } else if (faces < 12000000) {
         // XXL: 3M–12M
         lods = 4;

--- a/src/library/nxconv.cpp
+++ b/src/library/nxconv.cpp
@@ -415,6 +415,7 @@ bool getModelInfo(const std::string& inputModel, ModelInfo& info) {
         minX = minY = minZ = std::numeric_limits<double>::max();
         maxX = maxY = maxZ = std::numeric_limits<double>::lowest();
         bool any = false;
+        uint64_t localFaceCount = 0;
 
         for (unsigned m = 0; m < scene->mNumMeshes; ++m) {
             const aiMesh* mesh = scene->mMeshes[m];
@@ -431,7 +432,7 @@ bool getModelInfo(const std::string& inputModel, ModelInfo& info) {
                 any = true;
             }
             // Triangulate flag ensures mNumFaces is triangle count
-            info.faceCount += mesh->mNumFaces;
+            localFaceCount += mesh->mNumFaces;
         }
 
         if (!any)
@@ -444,6 +445,7 @@ bool getModelInfo(const std::string& inputModel, ModelInfo& info) {
         info.maxX = maxX;
         info.maxY = maxY;
         info.maxZ = maxZ;
+        info.faceCount = localFaceCount;
         return true;
     } catch (const std::exception& e) {
         LOGD << "getModelInfo failed for " << inputModel << ": " << e.what();

--- a/src/library/nxconv.cpp
+++ b/src/library/nxconv.cpp
@@ -401,13 +401,13 @@ static void exportWithAssimp(const aiScene* scene,
 
 
 bool getModelInfo(const std::string& inputModel, ModelInfo& info) {
-    // Bounds only: bake node transforms so vertices land in the model's root frame,
-    // and skip triangulation / normals / tangents / material work for speed. Wrapped
-    // in try/catch because indexing must never fail on a malformed model - the caller
+    // Bounds + face count: bake node transforms so vertices land in the model's root frame,
+    // triangulate for accurate face counts; skip normals / tangents / material work for speed.
+    // Wrapped in try/catch because indexing must never fail on a malformed model - the caller
     // simply gets no footprint.
     try {
         Assimp::Importer importer;
-        const aiScene* scene = importer.ReadFile(inputModel, aiProcess_PreTransformVertices);
+        const aiScene* scene = importer.ReadFile(inputModel, aiProcess_PreTransformVertices | aiProcess_Triangulate);
         if (scene == nullptr || scene->mNumMeshes == 0)
             return false;
 
@@ -430,6 +430,8 @@ bool getModelInfo(const std::string& inputModel, ModelInfo& info) {
                 maxZ = std::max(maxZ, static_cast<double>(p.z));
                 any = true;
             }
+            // Triangulate flag ensures mNumFaces is triangle count
+            info.faceCount += mesh->mNumFaces;
         }
 
         if (!any)

--- a/tests/obj2tiles_test.cpp
+++ b/tests/obj2tiles_test.cpp
@@ -258,23 +258,25 @@ TEST(obj2tiles, computeOptsMedium) {
     EXPECT_TRUE(opts.octree);
 }
 
-// Large band: 200K–750K → lods=3, divisions=1, octree=true (depth=3)
+// Large band: 200K–750K → lods=3, divisions=2, octree=true (depth=4)
+// (divisions bumped 1→2 vs. original bands: favors base-grid granularity over LOD depth)
 TEST(obj2tiles, computeOptsLarge) {
     ModelInfo info;
     info.faceCount = 500000;
     auto opts = computeObj2TilesOpts(info);
     EXPECT_EQ(opts.lods, 3);
-    EXPECT_EQ(opts.divisions, 1);
+    EXPECT_EQ(opts.divisions, 2);
     EXPECT_TRUE(opts.octree);
 }
 
-// XL band: 750K–3M → lods=3, divisions=2, octree=true (depth=4)
+// XL band: 750K–3M → lods=3, divisions=3, octree=true (depth=5)
+// (divisions bumped 2→3 vs. original bands: favors base-grid granularity over LOD depth)
 TEST(obj2tiles, computeOptsXL) {
     ModelInfo info;
     info.faceCount = 1500000u;
     auto opts = computeObj2TilesOpts(info);
     EXPECT_EQ(opts.lods, 3);
-    EXPECT_EQ(opts.divisions, 2);
+    EXPECT_EQ(opts.divisions, 3);
     EXPECT_TRUE(opts.octree);
 }
 

--- a/tests/obj2tiles_test.cpp
+++ b/tests/obj2tiles_test.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include <cmath>
+#include <cstdint>
 #include <fstream>
 
 #include "3d.h"
@@ -319,6 +320,9 @@ TEST(obj2tiles, forceDefaultsEnvVarParsing) {
         return env && env[0] != '0' && env[0] != '\0';
     };
 
+    // Save pre-existing value to restore afterwards
+    const char* saved = std::getenv("DDB_OBJ2TILES_FORCE_DEFAULTS");
+
     // Default: not set → false
     DDB_UNSETENV("DDB_OBJ2TILES_FORCE_DEFAULTS");
     EXPECT_FALSE(checkEnv());
@@ -339,9 +343,16 @@ TEST(obj2tiles, forceDefaultsEnvVarParsing) {
     DDB_SETENV("DDB_OBJ2TILES_FORCE_DEFAULTS", "");
     EXPECT_FALSE(checkEnv());
 
-    // Clean up
-    DDB_UNSETENV("DDB_OBJ2TILES_FORCE_DEFAULTS");
-    EXPECT_FALSE(checkEnv());
+    // Restore pre-existing value
+    if (saved) {
+        if (saved[0] == '\0') {
+            DDB_UNSETENV("DDB_OBJ2TILES_FORCE_DEFAULTS");
+        } else {
+            DDB_SETENV("DDB_OBJ2TILES_FORCE_DEFAULTS", saved);
+        }
+    } else {
+        DDB_UNSETENV("DDB_OBJ2TILES_FORCE_DEFAULTS");
+    }
 }
 
 // When force-defaults is active, a model that would normally get "Tiny" params

--- a/tests/obj2tiles_test.cpp
+++ b/tests/obj2tiles_test.cpp
@@ -221,6 +221,92 @@ TEST(obj2tiles, getModelInfoMissingReturnsFalse) {
     EXPECT_FALSE(getModelInfo(ta.getPath("does_not_exist.obj").string(), info));
 }
 
+// ---------------------------------------------------------------------------
+// computeObj2TilesOpts heuristic: verify all threshold bands
+// ---------------------------------------------------------------------------
+
+// Tiny band: < 10K faces → lods=1, divisions=0, octree=false (depth=0)
+TEST(obj2tiles, computeOptsTiny) {
+    ModelInfo info;
+    info.faceCount = 9999;
+    auto opts = computeObj2TilesOpts(info);
+    EXPECT_EQ(opts.lods, 1);
+    EXPECT_EQ(opts.divisions, 0);
+    EXPECT_FALSE(opts.octree);
+    EXPECT_EQ(opts.textureFormat, "Ktx2");
+    EXPECT_EQ(opts.ktx2Quality, 192);
+    EXPECT_EQ(opts.splitStrategy, "VertexMedian");
+}
+
+// Small band: 10K–50K → lods=2, divisions=0, octree=true (depth=1)
+TEST(obj2tiles, computeOptsSmall) {
+    ModelInfo info;
+    info.faceCount = 30000;
+    auto opts = computeObj2TilesOpts(info);
+    EXPECT_EQ(opts.lods, 2);
+    EXPECT_EQ(opts.divisions, 0);
+    EXPECT_TRUE(opts.octree);
+}
+
+// Medium band: 50K–200K → lods=2, divisions=1, octree=true (depth=2)
+TEST(obj2tiles, computeOptsMedium) {
+    ModelInfo info;
+    info.faceCount = 100000;
+    auto opts = computeObj2TilesOpts(info);
+    EXPECT_EQ(opts.lods, 2);
+    EXPECT_EQ(opts.divisions, 1);
+    EXPECT_TRUE(opts.octree);
+}
+
+// Large band: 200K–750K → lods=3, divisions=1, octree=true (depth=3)
+TEST(obj2tiles, computeOptsLarge) {
+    ModelInfo info;
+    info.faceCount = 500000;
+    auto opts = computeObj2TilesOpts(info);
+    EXPECT_EQ(opts.lods, 3);
+    EXPECT_EQ(opts.divisions, 1);
+    EXPECT_TRUE(opts.octree);
+}
+
+// XL band: 750K–3M → lods=3, divisions=2, octree=true (depth=4)
+TEST(obj2tiles, computeOptsXL) {
+    ModelInfo info;
+    info.faceCount = 1500000u;
+    auto opts = computeObj2TilesOpts(info);
+    EXPECT_EQ(opts.lods, 3);
+    EXPECT_EQ(opts.divisions, 2);
+    EXPECT_TRUE(opts.octree);
+}
+
+// XXL band: 3M–12M → lods=4, divisions=2, octree=true (depth=5)
+TEST(obj2tiles, computeOptsXXL) {
+    ModelInfo info;
+    info.faceCount = 6000000u;
+    auto opts = computeObj2TilesOpts(info);
+    EXPECT_EQ(opts.lods, 4);
+    EXPECT_EQ(opts.divisions, 2);
+    EXPECT_TRUE(opts.octree);
+}
+
+// Boundary: exactly 10K faces → Small band (not Tiny)
+TEST(obj2tiles, computeOptsBoundary10K) {
+    ModelInfo info;
+    info.faceCount = 10000;
+    auto opts = computeObj2TilesOpts(info);
+    EXPECT_EQ(opts.lods, 2);
+    EXPECT_EQ(opts.divisions, 0);
+    EXPECT_TRUE(opts.octree);
+}
+
+// Cap: even with astronomically large face count, depth never exceeds MAX_TILE_DEPTH (6)
+TEST(obj2tiles, computeOptsCapNeverExceedsMaxDepth) {
+    ModelInfo info;
+    info.faceCount = UINT64_MAX;
+    auto opts = computeObj2TilesOpts(info);
+    int depth = opts.octree ? (opts.lods + opts.divisions - 1) : opts.divisions;
+    EXPECT_LE(depth, 6);
+}
+
 // End-to-end georeferenced generation: a sidecar must yield a non-identity ECEF
 // transform in the tileset. Disabled on CI (needs the Obj2Tiles binary).
 MANUAL_TEST(obj2tiles, endToEndGeoreferenced) {

--- a/tests/obj2tiles_test.cpp
+++ b/tests/obj2tiles_test.cpp
@@ -307,6 +307,68 @@ TEST(obj2tiles, computeOptsCapNeverExceedsMaxDepth) {
     EXPECT_LE(depth, 6);
 }
 
+// Force-defaults env var: when DDB_OBJ2TILES_FORCE_DEFAULTS is set,
+// buildModel3DTiles should skip the heuristic and use hardcoded defaults.
+// This unit test verifies the env var parsing logic matches the same
+// lambda used in buildModel3DTiles() in 3d.cpp.
+TEST(obj2tiles, forceDefaultsEnvVarParsing) {
+    auto checkEnv = [] {
+        const char* env = std::getenv("DDB_OBJ2TILES_FORCE_DEFAULTS");
+        return env && env[0] != '0' && env[0] != '\0';
+    };
+
+    // Default: not set → false
+    DDB_UNSETENV("DDB_OBJ2TILES_FORCE_DEFAULTS");
+    EXPECT_FALSE(checkEnv());
+
+    // Set to "1" → true
+    DDB_SETENV("DDB_OBJ2TILES_FORCE_DEFAULTS", "1");
+    EXPECT_TRUE(checkEnv());
+
+    // Set to "true" → true
+    DDB_SETENV("DDB_OBJ2TILES_FORCE_DEFAULTS", "true");
+    EXPECT_TRUE(checkEnv());
+
+    // Set to "0" → false (explicitly disabled)
+    DDB_SETENV("DDB_OBJ2TILES_FORCE_DEFAULTS", "0");
+    EXPECT_FALSE(checkEnv());
+
+    // Set to empty string → false
+    DDB_SETENV("DDB_OBJ2TILES_FORCE_DEFAULTS", "");
+    EXPECT_FALSE(checkEnv());
+
+    // Clean up
+    DDB_UNSETENV("DDB_OBJ2TILES_FORCE_DEFAULTS");
+    EXPECT_FALSE(checkEnv());
+}
+
+// When force-defaults is active, a model that would normally get "Tiny" params
+// (< 10K faces → lods=1, divisions=0, octree=false) should instead get the
+// default (lods=3, divisions=3, octree=true). Verified via the env var path
+// producing the same result as the fallback defaults.
+TEST(obj2tiles, forceDefaultsProducesExpectedParams) {
+    // Simulate what buildModel3DTiles does when forceDefaults is true:
+    // it sets hardcoded defaults matching the "XXL" band
+    obj2tiles::Obj2TilesOptions forcedOpts;
+    forcedOpts.octree = true;
+    forcedOpts.divisions = 3;
+    forcedOpts.lods = 3;
+
+    // Verify these are the same defaults used in the fallback path
+    EXPECT_TRUE(forcedOpts.octree);
+    EXPECT_EQ(forcedOpts.divisions, 3);
+    EXPECT_EQ(forcedOpts.lods, 3);
+
+    // A tiny model's heuristic would give very different params
+    ModelInfo tinyInfo;
+    tinyInfo.faceCount = 100;
+    auto heuristicOpts = computeObj2TilesOpts(tinyInfo);
+    // Tiny band: lods=1, divisions=0, octree=false — definitely different
+    EXPECT_FALSE(heuristicOpts.octree);
+    EXPECT_EQ(heuristicOpts.divisions, 0);
+    EXPECT_EQ(heuristicOpts.lods, 1);
+}
+
 // End-to-end georeferenced generation: a sidecar must yield a non-identity ECEF
 // transform in the tileset. Disabled on CI (needs the Obj2Tiles binary).
 MANUAL_TEST(obj2tiles, endToEndGeoreferenced) {


### PR DESCRIPTION
New heuristics:

| Band | Faces | LODs | Divisions | Octree | Depth (lods + div - 1) |
|---|---|---|---|---|---|
| **Tiny** | < 10K | 1 | 0 | No | 0 (single tile) |
| **Small** | 10K – 50K | 2 | 0 | Yes | 1 |
| **Medium** | 50K – 200K | 2 | 1 | Yes | 2 |
| **Large** | 200K – 750K | 3 | 2 | Yes | 4 |
| **XL** | 750K – 3M | 3 | 3 | Yes | 5 |
| **XXL** | 3M – 12M | 4 | 2 | Yes | 5 |
| **Massive** | > 12M | 4 | 3 | Yes | clamped to 6 |

**Always set** (same across all bands):

| Option | Value |
|---|---|
| `textureFormat` | `"Ktx2"` |
| `ktx2Quality` | `192` |
| `splitStrategy` | `"VertexMedian"` |

**Hard cap**: Depth never exceeds `MAX_TILE_DEPTH = 6`. If `lods + divisions - 1 > 6`, LODs is reduced first (preserves finer base grid, coarser LOD hierarchy).

**Override**: `DDB_OBJ2TILES_FORCE_DEFAULTS` env var or `--force-defaults` CLI flag → hardcoded `divisions=3, lods=3, octree=true`.